### PR TITLE
Remove dep on vm-shim.

### DIFF
--- a/client/modules/module_manager.js
+++ b/client/modules/module_manager.js
@@ -18,7 +18,6 @@ define(function(require) {
   var _ = require('underscore');
   var L = require('leaflet');
   require('leaflet-edgebuffer');
-  var vm = require('vm-shim');
   var Noise = require('noisejs');
 
   var asset = require('client/asset/asset');
@@ -36,6 +35,7 @@ define(function(require) {
   var ClientStateMachine = require('client/modules/client_state_machine');
   var fakeRequire = require('lib/fake_require');
   var geometry = require('lib/geometry');
+  var safeEval = require('lib/eval');
   var loadYoutubeApi = require('client/util/load_youtube_api');
   var StateManager = require('client/state/state_manager');
   var NeighborPersistence = require('client/network/neighbor_persistence');
@@ -86,7 +86,7 @@ define(function(require) {
         loadYoutubeApi: loadYoutubeApi,
         debug: debug('wall:module:' + name),
       }, dependencies);
-      vm.runInNewContext(code, sandbox);
+      safeEval(code, sandbox);
       if (!def) {
         throw new Error('Failed to parse module ' + name);
       }

--- a/lib/eval.js
+++ b/lib/eval.js
@@ -1,0 +1,42 @@
+/* Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+(function(factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  }
+}(function() {
+  'use strict';
+  // Eval something as safe as we can in the browser.
+  // We need to pay attention to things like sourceUrls and line numbers and
+  // strict mode.
+  return function(source, sandbox) {
+    var sandboxKeys = Object.keys(sandbox);
+    var functionParams = sandboxKeys.concat([source]);
+
+    var Sandbox = function(args) {
+      return Function.apply(this, args);
+    };
+    Sandbox.prototype = Function.prototype;
+    var sandboxFn = new Sandbox(functionParams);
+    return sandboxFn.apply(null, sandboxKeys.map((k) => sandbox[k]));
+  };
+}));

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "socket.io-client": "^1.3.5",
     "three": "^0.72.0",
     "underscore": "^1.8.3",
-    "vm-shim": "artdent/vm-shim",
     "x2x": "^1.0.0",
     "xml2js": "^0.4.12"
   },


### PR DESCRIPTION
Replace with a custom safeEval script, which does a better job of handling
line number failures, which makes debugging modules far easier.

Fixes #21.