### PR TITLE
Fixing a terribly obscure edge case in state.

### DIFF
--- a/lib/shared_state.js
+++ b/lib/shared_state.js
@@ -61,11 +61,11 @@ limitations under the License.
       return null;
     }
     // Too early!
-    if (t < this.store_[0].time) {
+    if (t <= this.store_[0].time) {
       return this.store_[0].value;
     }
     // Too late!
-    if (t > this.store_[this.store_.length-1].time) {
+    if (t >= this.store_[this.store_.length-1].time) {
       return this.store_[this.store_.length-1].value;
     }
     


### PR DESCRIPTION
It's technically possible for us to return 'undefined' from .get, when the state
array has only 1 value and the requested time is identical to that tuple's time.
This is not likely the cause of #3, but is certainly related.