### PR TITLE
Streamline jshint checking and make everything jshint clean.

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,1 +1,1 @@
-node_modules
+node_modules/**

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,7 @@
 {
   "-W041": false,  /* Disable "Use '===' to compare with 0". */
   "-W058": true,  /* Disable 'Missing () invoking a constructor' */
+  "-W126": false,  /* Disable 'Unnecessary grouping operator.' */
   "newcap": false,
   "curly": true,
   "eqeqeq": false,
@@ -13,6 +14,9 @@
   "singleGroups": true,
   "undef": true,
   "unused": "vars",
-  "esnext": true,
-  "predef": ["Path2D"]
+  "esnext": true,  
+  "globals": {
+    "require": true,
+    "console": true
+  }
 }

--- a/lib/.jshintrc
+++ b/lib/.jshintrc
@@ -4,11 +4,14 @@
     "ServerModuleInterface": true,
     "ClientModuleInterface": true,
     "debug": true,
+    "module": true,
+    "define": true,
     "geometry": true,
     "Q": true,
     "Surface": true,
     "wallGeometry": true,
     "loadYoutubeApi": true,
+    "setTimeout": true,
     "YT": true,
     "register": true,
     "network": true,
@@ -17,4 +20,3 @@
   },
   "strict": false
 }
-

--- a/lib/assert.js
+++ b/lib/assert.js
@@ -31,5 +31,5 @@ limitations under the License.
       console.error.apply(console, ['Assertion failure!'].concat(rest));
       throw new Error('Assertion failure!');
     }
-  }
+  };
 }));

--- a/lib/fake_require.js
+++ b/lib/fake_require.js
@@ -32,7 +32,7 @@ limitations under the License.
         } else {
           return require(path);
         }
-      }
+      };
     },
   };
 }));

--- a/lib/geometry.js
+++ b/lib/geometry.js
@@ -137,11 +137,11 @@ limitations under the License.
       return (bx-ax)*(y-ay) - (by-ay)*(x-ax);
     },
     onLine: function(ax, ay, bx, by, x, y) {
-      return Math.abs(geo.side(ax, ay, bx, by, x, y)) < 0.0001
-          && x >= Math.min(ax, bx)
-          && x <= Math.max(ax, bx)
-          && y >= Math.min(ay, by)
-          && y <= Math.max(ay, by);
+      return Math.abs(geo.side(ax, ay, bx, by, x, y)) < 0.0001 &&
+                  x >= Math.min(ax, bx) &&
+                  x <= Math.max(ax, bx) &&
+                  y >= Math.min(ay, by) &&
+                  y <= Math.max(ay, by);
     },
     onPoly: function(polygon, x, y) {
       for (var i=1; i < polygon.points.length; i++) {
@@ -167,7 +167,7 @@ limitations under the License.
       return sum > 0;
     },
     isConvex: function(polygon) {
-      var n = polygon.points.length; 
+      var n = polygon.points.length;
       if (n <= 3) {
         return true;
       }
@@ -195,7 +195,7 @@ limitations under the License.
     isInside: function(polygon, x, y) {
       // NOTE(applmak): Left-of-side tests only work for SIMPLE polygons.
       // /me is ashamed.
-      
+
       var numberOfCrossings = 0;
       for (var i=1; i < polygon.points.length; i++) {
         var a = polygon.points[i-1];
@@ -218,10 +218,10 @@ limitations under the License.
     },
     // Damn it! Here I am, solving line segment intersection AGAIN.
     // You think I would have learned my lesson by now. :(
-    // 
+    //
     // Given line segment ab and line segment cd, determine if there is an
     // intersection point:
-    //   First, write ab and cd as parametric equations with variables u and v 
+    //   First, write ab and cd as parametric equations with variables u and v
     //     in [0,1]:
     //     l(ab) = a + (b - a)*u
     //     l(cd) = c + (d - c)*v
@@ -254,7 +254,7 @@ limitations under the License.
         // Lines are parallel.
         return null;
       }
-      
+
       var u = ((dx - cx)*(ay - cy) - (dy - cy)*(ax - cx))/det;
       if (u < 0 || u > 1) {
         // Lines intersect; segments don't.
@@ -269,7 +269,7 @@ limitations under the License.
         // Lines intersect; segments don't.
         return null;
       }
-      
+
       // Send additional data for those curious.
       return {x: ax + (bx - ax) * u,
               y: ay + (by - ay) * u,
@@ -313,7 +313,7 @@ limitations under the License.
       for (var i = 0; i < polygon.points.length; ++i) {
         var p1 = polygon.points[i];
         var p2 = polygon.points[(i + 1) % polygon.points.length];
-        
+
         var det1 = geo.side(ax, ay, bx, by, p1.x, p1.y);
         var points = det1 > 0 ? leftPoints : rightPoints;
         var otherPoints = points === leftPoints ? rightPoints : leftPoints;
@@ -332,17 +332,17 @@ limitations under the License.
           }
           continue;
         }
-        
+
         // Add p1 to the current point list.
         points.push({x: p1.x, y: p1.y});
-          
+
         var det2 = geo.side(ax, ay, bx, by, p2.x, p2.y);
         // Is the next point on the same side?
         if (Math.sign(det2) == Math.sign(det1)) {
           // Great! Next iteration will do the work.
           continue;
         }
-        
+
         // Ah, next point is on the OTHER side (or on the line).
         // Find the intersection point of the cutline and the current line.
         var point = geo.intersection(ax, ay, bx, by, p1.x, p1.y, p2.x, p2.y);
@@ -354,7 +354,7 @@ limitations under the License.
         // the other list of points to ensure that they are noticed there.
         otherPoints.push(point);
       }
-      
+
       // Duplicate the first point at the end.
       if (leftPoints.length) {
         leftPoints.push({x: leftPoints[0].x, y: leftPoints[0].y});
@@ -362,9 +362,9 @@ limitations under the License.
       if (rightPoints.length) {
         rightPoints.push({x: rightPoints[0].x, y: rightPoints[0].y});
       }
-      
+
       return {left: new geo.Polygon(leftPoints),
-              right: new geo.Polygon(rightPoints)}
+              right: new geo.Polygon(rightPoints)};
     },
     distanceToPolygon: function(polygon, x, y) {
       var minDistance = Infinity;
@@ -394,9 +394,9 @@ limitations under the License.
       return geo.distance(xp, yp, projx, projy);
     },
     distance: function(x1, y1, x2, y2) {
-      return Math.sqrt(Math.pow((x2 - x1), 2) + Math.pow((y2 - y1), 2));
+      return Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
     },
   };
-  
+
   return geo;
 }));

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -29,21 +29,21 @@ limitations under the License.
       setTimeout(resolve, ms);
     });
   };
-  
+
   Promise.prototype.done = function(opt_resolve, opt_reject) {
     this.then(opt_resolve, opt_reject).catch(function(e) {
       console.error('Unhandled rejection!', e.message);
       console.error(e.stack);
     });
   };
-  
+
   Promise.allSettled = function(promises) {
     var statuses = [];
     return promises.reduce((agg, promise, index) => {
       return promise.then((v) => {
         statuses[index] = {status: 'resolved', value: v};
       }, (e) => {
-        statuses[index] = {status: 'rejected', error: e}
+        statuses[index] = {status: 'rejected', error: e};
       }).then(() => agg);
     }, Promise.resolve())
         .then(() => statuses);

--- a/lib/rectangle.js
+++ b/lib/rectangle.js
@@ -39,14 +39,17 @@ define(function(require) {
     return [ this.x, this.y, this.w, this.h ].join(',');
   };
   Rectangle.prototype.intersects = function(that) {
-    if (this.x >= that.x + that.w)
+    // TODO this can be a (long) one liner.
+    if (this.x >= that.x + that.w) {
       return false;
-    if (this.y >= that.y + that.h)
+    } else if (this.y >= that.y + that.h) {
       return false;
-    if (this.x + this.w <= that.x)
+    } else if (this.x + this.w <= that.x) {
       return false;
-    if (this.y + this.h <= that.y)
+    } else if (this.y + this.h <= that.y) {
       return false;
+    }
+
     return true;
   };
   return Rectangle;

--- a/lib/shared_state.js
+++ b/lib/shared_state.js
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 // This is gobbledegook that we need to have a node-complaint module def in JS
-// while at the same time supporting our requirejs loader in the browser. 
+// while at the same time supporting our requirejs loader in the browser.
 // If we converted to ES6' modules, this would go away.
 (function(factory) {
   if (typeof define === 'function' && define.amd) {
@@ -38,7 +38,7 @@ limitations under the License.
   var SharedState = function(name, interpolator, owner) {
     // For debugging purposes only.
     this.name_ = name;
-    
+
     // A store of timestamp, value tuples. We store no more than the last 10
     // samples of the state. On both the client and the server, the times are in
     // server-time.
@@ -50,12 +50,12 @@ limitations under the License.
     // Owner of the state: either a client socket id or 'server'.
     this.owner_ = owner;
   };
-  
+
   // Returns the value of the shared state, according to the specific kind of
   // variable & interpolator.
   SharedState.prototype.get = function(opt_time) {
     var t = opt_time || time.now();
-    
+
     // Edge cases: No data!
     if (this.store_.length === 0) {
       return null;
@@ -68,7 +68,7 @@ limitations under the License.
     if (t >= this.store_[this.store_.length-1].time) {
       return this.store_[this.store_.length-1].value;
     }
-    
+
     for (var i = 1; i < this.store_.length; i++) {
       var a = this.store_[i-1];
       var b = this.store_[i];
@@ -76,24 +76,24 @@ limitations under the License.
         return this.interpolator_(t, a.time, a.value, b.time, b.value);
       }
     }
-    
+
     // Huh?
     return null;
   };
-  
+
   // Sets the current value of the state.
   SharedState.prototype.set = function(value, time) {
     this.store_.push({
       time: time,
       value: value
     });
-    
+
     // Ensure there are no more than 10 entries.
     while (this.store_.length > 10) {
       this.store_.shift();
     }
   };
-  
+
   // The lerp interpolator walks the store, looking for a time value between
   // the start and end. If it finds one, we lerp between the values. If not, we
   // use the start or end, appropriately.
@@ -144,20 +144,20 @@ limitations under the License.
         }
       }
 
-      for (var k in bv) {
-        if (!k in av) {
-          ret[k] = bv[k]
+      for (k in bv) {
+        if (!(k in av)) {
+          ret[k] = bv[k];
         }
       }
 
       return ret;
     };
   }
-  
+
   function ArrayInterpolatorGenerator(def) {
     // Def is an array of 1 generator reference.
     var dynamicInterpolator = decodeInterpolator(def[0]);
-    
+
     return function ArrayInterpolator(time, at, av, bt, bv) {
       av = av || [];
       bv = bv || [];
@@ -166,13 +166,13 @@ limitations under the License.
       });
     };
   }
-  
+
   var simpleInterpolators = [
     NumberLerpInterpolator,
     ValueNearestInterpolator,
     CurrentValueInterpolator
   ];
-  
+
   function decodeInterpolator(def) {
     if (typeof def === 'string') {
       // simple interpolator!
@@ -187,7 +187,7 @@ limitations under the License.
       return ObjectInterpolatorGenerator(def);
     }
   }
-  
+
   return {
     SharedState: SharedState,
     addSimpleInterpolator: function(interpolator) {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,7 @@
   "main": "server/server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "clienthint": "node_modules/.bin/jshint --exclude-path .gitignore client/*.js client/*/*.js",
-    "serverhint": "node_modules/.bin/jshint --exclude-path .gitignore server/*.js server/*/*.js",
-    "modulehint": "node_modules/.bin/jshint --exclude-path .gitignore demo_modules/*/*.js",
-    "lint": "jshint .",
-    "validate": "npm ls"
+    "jshint": "node_modules/.bin/jshint **/*.js"
   },
   "author": "",
   "license": "MIT",
@@ -44,14 +40,11 @@
     "xml2js": "^0.4.12"
   },
   "pre-commit": [
-    "clienthint",
-    "serverhint",
-    "modulehint"
+    "jshint"
   ],
   "devDependencies": {
     "jshint": "^2.8.0",
     "node-inspector": "^0.12.5",
-    "pre-commit": "^1.0.10",
-    "precommit-hook": "^3.0.0"
+    "pre-commit": "^1.0.10"
   }
 }


### PR DESCRIPTION
Run just a single jshint across entire repo (excluding node_modules).
This will catch things missed before (e.g., ```lib/```) and is still faster
because of the single ```npm run ...``` command.

PR also fixes a few jshint errors in ```lib/``` and removes the unused ```precommit-hook``` dev dependency (```pre-commit``` is sufficient for running basic npm scripts before commit).