### PR TITLE
Add a flag for the node_modules dir.

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -27,8 +27,17 @@ var wallGeometry = require('server/util/wall_geometry');
 var Control = require('server/control');
 var webapp = require('server/webapp');
 var credentials = require('server/util/credentials');
+var path = require('path');
+
+console.log('__dirname is ' + __dirname);
 
 var cli = commandLineArgs([
+  {name: 'node_modules_dir', type: String,
+      defaultValue: path.join(__dirname, 'node_modules'),
+      description: 'If you are running a chicago-brick instance where ' +
+          'chicago-brick is a dep and lives in node_modules, you must set ' +
+          'this to your project\'s node_modules dir or the /sys path will ' +
+          'be set to a nonexistent directory.'},
   {name: 'playlist', type: String, alias: 'p',
       defaultValue: 'config/demo-playlist.json'},
   {name: 'assets_dir', type: String, alias: 'd',

--- a/server/server.js
+++ b/server/server.js
@@ -29,11 +29,9 @@ var webapp = require('server/webapp');
 var credentials = require('server/util/credentials');
 var path = require('path');
 
-console.log('__dirname is ' + __dirname);
-
 var cli = commandLineArgs([
   {name: 'node_modules_dir', type: String,
-      defaultValue: path.join(__dirname, 'node_modules'),
+      defaultValue: path.join(__dirname, '..', 'node_modules'),
       description: 'If you are running a chicago-brick instance where ' +
           'chicago-brick is a dep and lives in node_modules, you must set ' +
           'this to your project\'s node_modules dir or the /sys path will ' +

--- a/server/webapp.js
+++ b/server/webapp.js
@@ -34,6 +34,9 @@ function create(flags) {
   // TODO(applmak): Figure out a way so that chicago-brick can be require'd, and
   // used as a normal node dep.
   let base = path.join(__dirname, '..');
+
+  console.log('base is ' + base);
+  console.log('node_modules_dir is ' + flags.node_modules_dir);
   
   // Sub-app showing the status page.
   var status = express();
@@ -44,7 +47,7 @@ function create(flags) {
   app.use('/status', status);
   app.use('/client', express.static(path.join(base, 'client')));
   app.use('/lib', express.static(path.join(base, 'lib')));
-  app.use('/sys', express.static(path.join(base, 'node_modules')));
+  app.use('/sys', express.static(flags.node_modules_dir));
   for (let assets_dir of flags.assets_dir) {
     app.use('/asset', express.static(assets_dir));
   }

--- a/server/webapp.js
+++ b/server/webapp.js
@@ -18,6 +18,7 @@ limitations under the License.
 var path = require('path');
 
 var bodyParser = require('body-parser');
+var debug = require('debug')('wall:webapp');
 var express = require('express');
 
 /**
@@ -35,8 +36,8 @@ function create(flags) {
   // used as a normal node dep.
   let base = path.join(__dirname, '..');
 
-  console.log('base is ' + base);
-  console.log('node_modules_dir is ' + flags.node_modules_dir);
+  debug('webapp base dir is ' + base);
+  debug('node_modules_dir is ' + flags.node_modules_dir);
   
   // Sub-app showing the status page.
   var status = express();
@@ -52,7 +53,6 @@ function create(flags) {
     app.use('/asset', express.static(assets_dir));
   }
 
-  
   app.use(express.static(path.join(base, 'client')));
 
   // Needed by control.js for POST requests.


### PR DESCRIPTION
With this patch, chicago-brick can be run from a project that includes chicago-brick as a dep in package.json with just an extra --node_modules_dir flag.

fixes #74 