### PR TITLE
Allow files required by modules to export symbols.

### DIFF
--- a/server/webapp.js
+++ b/server/webapp.js
@@ -73,7 +73,7 @@ function create(flags) {
         res.removeHeader('Content-Length');
     
         // After headers, but before the real content, add the wrapping marker.
-        write.call(res, 'define(function(require) {\n');
+        write.call(res, 'define(function(require, exports, module) {\n');
         write.apply(res, Array.from(arguments));
         // Restore original write function, so subsequent writes work just fine.
         res.write = write;


### PR DESCRIPTION
Without this change, we can technically require other files, but those files can't expose any symbols, which is totally useless!

Multi-file modules are 100% working after this, but I think there's only 1 last wonky bit in the server before we are really done.