### PR TITLE
Fix title card.

### DIFF
--- a/server/modules/module_def.js
+++ b/server/modules/module_def.js
@@ -173,8 +173,12 @@ class ModuleDef extends EventEmitter {
   }
   // Returns a new module def that extends this def with new configuration.
   extend(name, title, author, config) {
-    return new ModuleDef(name, this,
-      title || this.title, author || this.author, config);
+    return new ModuleDef(
+      name,
+      this,
+      title === undefined ? '' : (title || this.title),
+      author === undefined ? '' : (author || this.author),
+      config);
   }
   
   // Loads a module from disk asynchronously, assigning def when complete.


### PR DESCRIPTION
Prior to this CL, there was no way to hide an overridden module's title or author. Now, eliding these keys from the config will cause the title card to not show those fields.

Closes #56.