### PR TITLE
Use built-in node debugging.

### DIFF
--- a/bin/run_1x1.sh
+++ b/bin/run_1x1.sh
@@ -17,12 +17,13 @@
 
 set -x
 
-NODE=node
 if [[ $NODEDEBUG ]]; then
-  NODE=./node_modules/node-inspector/bin/node-debug.js
+  INSPECT="--debug-brk --inspect"
+else
+  INSPECT=""
 fi
 
-DEBUG=wall:* NODE_PATH=. $NODE server/server.js \
+DEBUG=wall:* NODE_PATH=. node $INSPECT server/server.js \
   --use_geometry '[{"right":1},{"down":1},{"left":1},{"up":1}]' \
   --assets_dir demo_assets \
   $@

--- a/bin/run_2x2.sh
+++ b/bin/run_2x2.sh
@@ -17,12 +17,13 @@
 
 set -x
 
-NODE=node
 if [[ $NODEDEBUG ]]; then
-  NODE=./node_modules/node-inspector/bin/node-debug.js
+  INSPECT="--debug-brk --inspect"
+else
+  INSPECT=""
 fi
 
-DEBUG=wall:* NODE_PATH=. $NODE server/server.js \
+DEBUG=wall:* NODE_PATH=. node $INSPECT server/server.js \
   --use_geometry '[{"right":2},{"down":2},{"left":2},{"up":2}]' \
   --assets_dir demo_assets \
   $@

--- a/bin/run_chev6.sh
+++ b/bin/run_chev6.sh
@@ -17,12 +17,13 @@
 
 set -x
 
-NODE=node
 if [[ $NODEDEBUG ]]; then
-  NODE=./node_modules/node-inspector/bin/node-debug.js
+  INSPECT="--debug-brk --inspect"
+else
+  INSPECT=""
 fi
 
-DEBUG=wall:* NODE_PATH=. $NODE server/server.js \
+DEBUG=wall:* NODE_PATH=. node $INSPECT server/server.js \
   --use_geometry '[{"right":2},{"down":1},{"right":1},{"down":1},{"left":1},{"down":1},{"left":2},{"up":1},{"right":1},{"up":1},{"left":1},{"up":1}]' \
   --assets_dir demo_assets \
   $@

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   ],
   "devDependencies": {
     "jshint": "^2.8.0",
-    "node-inspector": "^0.12.5",
     "pre-commit": "^1.0.10"
   }
 }


### PR DESCRIPTION
New versions of node have built-in debugging now. We no longer need
node-inspector.