### PR TITLE
Fix network.

### DIFF
--- a/client/network/network.js
+++ b/client/network/network.js
@@ -43,8 +43,14 @@ define(function(require) {
       return {
         open: function() {
           var baseAddr = location.protocol + '//' + location.host;
-          var addr = `${baseAddr}/${externalNspName}?id=${id}&rect=${info.virtualRectNoBezel.serialize()}`;
-          moduleSocket = io(addr, {multiplex: false});
+          var addr = `${baseAddr}/${externalNspName}`;
+          moduleSocket = io(addr, {
+            multiplex: false,
+            query: {
+              id,
+              rect: info.virtualRectNoBezel.serialize()
+            }
+          });
           debug('Opened per-module socket @ ' + externalNspName);
           return moduleSocket;
         },

--- a/server/network/network.js
+++ b/server/network/network.js
@@ -122,9 +122,9 @@ network.forModule = function(id) {
   var clients = [];
   return {
     open: function() {
-      debug('Opened per-module socket @ ' + id);
+      debug('Opened per-module socket @ ' + id, internalNspName);
       console.assert(!io.nsps[internalNspName]);
-      var nsp = io.of(externalNspName);
+      var nsp = io.of(internalNspName);
 
       // Expose ioClient via network module.
       nsp.openExternalSocket = function(host) {


### PR DESCRIPTION
socket.io 1.5 introduced a new way to pass query params in, which is incompatible
with the old way. Also, they changed the way namespaces work, so reverted to the
new internal name on the server.