### PR TITLE
Update chicago-brick-live to use serverRequire for socket.io-client.

### DIFF
--- a/demo_modules/chicago-brick-live/chicago-brick-live.js
+++ b/demo_modules/chicago-brick-live/chicago-brick-live.js
@@ -86,7 +86,7 @@ class ChicagoBrickLiveServer extends ModuleInterface.Server {
     // of global code changes (e.g., codeserver comes online) and cache code.
     this.clients = {};
 
-    this.codeServer = require('socket.io-client')(this.config.codeServer);
+    this.codeServer = serverRequire('socket.io-client')(this.config.codeServer);
 
     // Setup connection to code server.
     this.codeServer.on('connect', () => {


### PR DESCRIPTION
This fixes an issue causing chicago-brick-live to not be able to run
with the (semi) recent changes to how client and server require's
are handled.