### PR TITLE
More slideshow fixes & debugging

### DIFF
--- a/demo_modules/slideshow/load_from_drive.js
+++ b/demo_modules/slideshow/load_from_drive.js
@@ -108,13 +108,19 @@ class LoadFromDriveClientStrategy extends interfaces.ClientLoadStrategy {
             var img = document.createElement('img');
             img.src = url;
             // Don't report that we've loaded the image until onload fires.
-            img.addEventListener('load', () => resolve(img));
-            img.addEventListener('error', () => reject(new Error));
+            img.addEventListener('load', () => {
+              URL.revokeObjectURL(url);
+              resolve(img);
+            });
+            img.addEventListener('error', () => reject(new Error(`${type}, ${url}`)));
           } else if (type.indexOf('video') != -1) {
             var video = document.createElement('video');
             video.src = url;
             video.autoplay = true;
-            video.addEventListener('load', () => resolve(video));
+            video.addEventListener('load', () => {
+              URL.revokeObjectURL(url);
+              resolve(video);
+            });
             video.addEventListener('error', () => reject(new Error));
           } else {
             throw new Error('Unknown MIME type for drive file: ' + type);

--- a/demo_modules/slideshow/slideshow.js
+++ b/demo_modules/slideshow/slideshow.js
@@ -156,6 +156,11 @@ class ImageClient extends ModuleInterface.Client {
       });
     });
   }
+  finishFadeOut() {
+    if (this.surface) {
+      this.surface.destroy();
+    }
+  }
   draw(time, delta) {
     if (this.displayStrategy) {
       this.displayStrategy.draw(time, delta);


### PR DESCRIPTION
Found a couple more bugs in the slideshow module. Turns out, you need to revoke your object urls after you are done with them, as their default lifetime is that of the `document`. Whoops! Also, we weren't cleaning up our surface. DOUBLE WHOOPS.