### PR TITLE
Replace handleError API with errorlistener in sm.

### DIFF
--- a/client/modules/client_state_machine.js
+++ b/client/modules/client_state_machine.js
@@ -208,6 +208,18 @@ define(function(require) {
     constructor() {
       // Initially, we tell the clients to show a blank screen.
       super(new DisplayState(ClientModule.newEmptyModule()), debug);
+      
+      this.setErrorListener(error => {
+        if (monitor.isEnabled()) {
+          monitor.update({client: {
+            event: error.toString(),
+            time: timeManager.now(),
+            color: [255, 0, 0]
+          }});
+        }
+        
+        logError(error);
+      });
     }
     nextModule(module) {
       if (monitor.isEnabled()) {
@@ -221,22 +233,6 @@ define(function(require) {
       debug('Requested transition to module', module.name);
       // Transition according to current state rules.
       this.state.nextModule(module);
-    }
-    handleError(error) {
-      if (monitor.isEnabled()) {
-        monitor.update({client: {
-          event: error.toString(),
-          time: timeManager.now(),
-          color: [255, 0, 0]
-        }});
-      }
-      
-      logError(error);
-      // If we bubble up an error this far, we transition instantly back to a 
-      // blank screen.
-      this.transitionTo(new DisplayState(ClientModule.newEmptyModule()));
-      // Re-enable the state machine.
-      this.driveMachine();
     }
   }
 

--- a/lib/state_machine.js
+++ b/lib/state_machine.js
@@ -52,6 +52,9 @@ limitations under the License.
    */
   class StateMachine {
     constructor(initialState, debug = undefined) {
+      // Remember the initial state. We'll return to it when an error occurs.
+      this.initialState_ = initialState;
+      
       // We don't transition to the initial state; we are simply in that state 
       // to begin with.
       this.state = initialState;
@@ -76,6 +79,12 @@ limitations under the License.
        */
       this.context_ = undefined;
     
+      /**
+       * An error listener, which is invoked when an error occurs.
+       * The default one just swallows all errors.
+       */
+      this.errorListener_ = error => {};
+      
       this.driveMachine();
       this.state.enter(this.resolver_, this.context_);
     }
@@ -120,6 +129,13 @@ limitations under the License.
     }
   
     /**
+     * Sets the error listener to the passed-in handler.
+     */
+    setErrorListener(handler) {
+      this.errorListener_ = handler;
+    }
+    
+    /**
      * Returns a promise that's resolved when the current transition finishes. If
      * there is no current transitions, it will resolve when the next transition
      * requested completes.
@@ -129,11 +145,6 @@ limitations under the License.
         this.transitionPromise_.then(resolve, reject);
       });
     }
-  
-    /**
-     * When an exception is thrown during a transition, we call this method.
-     */
-    handleError(error) {}
   
     /**
      * Waits for a transition to be requested, then performs the transition,
@@ -189,7 +200,15 @@ limitations under the License.
         // Whoa! Some kind of exception occurred while we were attempting to do
         // a transition. Delegate to the error handler. The error handler is
         // responsible for resuming the state machine.
-        this.handleError(error);
+        if (this.errorListener_) {
+          this.errorListener_(error);
+        }
+        
+        // Go back to the initial state.
+        this.transitionTo(this.initialState_);
+        
+        // Restart the engine.
+        this.driveMachine();
       });
     }
   }


### PR DESCRIPTION
Our eventual goal is to have some external system driving the state machines, rather than the state machines driving themselves to the next module. Part of this is recovering correctly when an error occurs. The current implementation of error handling forces each sm to know about how to recover. The new error handling allows other systems (such as parent sms) to be told when an error occurs and to tell that state machine to do something about it.

This actually fixes a potential bug that I hadn't considered before now where a single client sm might have gotten screwed up, but the wall wouldn't have advanced the whole wall to the next module. Now, we theoretically handle this correctly. I'm not sure if this even happened in practice, though.