### PR TITLE
Fix layout fadeout.

### DIFF
--- a/client/modules/module.js
+++ b/client/modules/module.js
@@ -106,11 +106,12 @@ define(function(require) {
     }
 
     instantiate() {
+      this.container = createNewContainer(this.name);
+      
       if (!this.path) {
         return Promise.resolve();
       }
       
-      this.container = createNewContainer(this.name);
       this.network = network.forModule(
         `${this.geo.extents.serialize()}-${this.deadline}`);
       let openNetwork = this.network.open();
@@ -186,6 +187,10 @@ define(function(require) {
 
     // Returns true if module is still OK.
     fadeIn(deadline) {
+      this.container.style.transition =
+          'opacity ' + timeManager.until(deadline).toFixed(0) + 'ms';
+      this.container.style.opacity = 1.0;
+      
       if (!this.path) {
         return true;
       }
@@ -196,9 +201,6 @@ define(function(require) {
         return false;
       }
       moduleTicker.add(this.name, this.instance, this.globals);
-      this.container.style.transition =
-          'opacity ' + timeManager.until(deadline).toFixed(0) + 'ms';
-      this.container.style.opacity = 1.0;
       Promise.delay(timeManager.until(deadline)).done(() => {
         this.titleCard.enter();
         try {
@@ -211,6 +213,11 @@ define(function(require) {
     }
 
     fadeOut(deadline) {
+      if (this.container) {
+        this.container.style.transition =
+            'opacity ' + timeManager.until(deadline).toFixed(0) + 'ms';
+        this.container.style.opacity = 0.0;
+      }
       if (!this.path) {
         return true;
       }
@@ -220,13 +227,14 @@ define(function(require) {
       } catch(e) {
         error(e);
       }
-      this.container.style.transition =
-          'opacity ' + timeManager.until(deadline).toFixed(0) + 'ms';
-      this.container.style.opacity = 0.0;
       return true;
     }
 
     dispose() {
+      if (this.container) {
+        this.container.remove();
+        this.container = null;
+      }
       if (!this.path) {
         return true;
       }
@@ -242,8 +250,6 @@ define(function(require) {
         error(e);
       }
       
-      this.container.remove();
-      this.container = null;      
       return true;
     }
   }

--- a/client/style.css
+++ b/client/style.css
@@ -28,6 +28,7 @@ html, body, #containers {
     bottom: 0;
     position: absolute;
     overflow: hidden;
+    background-color: black;
 }
 canvas {
     width: 100%;

--- a/server/modules/layout_state_machine.js
+++ b/server/modules/layout_state_machine.js
@@ -242,22 +242,24 @@ class FadeOutState extends stateMachine.State {
     this.timer_ = null;
   }
   enter(transition) {
-    let deadline = time.inFuture(5000);
+    let now = time.now();
+    const FADE_OUT_DURATION = 5000;
+    let deadline = now + FADE_OUT_DURATION;
     if (monitor.isEnabled()) {
       monitor.update({layout: {
-        time: time.now(),
+        time: now,
         state: this.getName(),
-        deadline: deadline
+        deadline: deadline,
       }});
     }
     
     this.transition_ = transition;
     debug(`Fading out ${this.partition_.length} layouts at ${deadline} ms`);
-    this.partition_.forEach(sm => sm.fadeToBlack(deadline));
+    this.partition_.forEach(sm => sm.fadeToBlack(now));
     this.timer_ = setTimeout(() => {
       let index = (this.index_ + 1) % this.layouts_.length;
-      transition(new DisplayState(this.layouts_, deadline + 5000, index));
-    }, 5000);
+      transition(new DisplayState(this.layouts_, deadline, index));
+    }, time.until(deadline));
   }
   exit() {
     clearTimeout(this.timer_);

--- a/server/modules/module_def.js
+++ b/server/modules/module_def.js
@@ -109,9 +109,6 @@ const verify = (name, contents) => {
  * instantiate a module, including code location and config parameters.
  */
 class ModuleDef extends EventEmitter {
-  static emptyModule() {
-    return new EmptyModuleDef;
-  }
   constructor(name, pathOrBaseModule, title, author, config) {
     super();
     this.name = name;
@@ -246,14 +243,6 @@ class ModuleDef extends EventEmitter {
       title: this.title,
       author: this.author,
     };
-  }
-}
-
-class EmptyModuleDef extends ModuleDef {
-  constructor() {
-    super('_empty');
-    // TODO(applmak): ^ this hacky.
-    // However, b/c of the hack, this module will never become valid.
   }
 }
 

--- a/server/modules/module_library.js
+++ b/server/modules/module_library.js
@@ -15,15 +15,24 @@ limitations under the License.
 
 'use strict';
 
-var EventEmitter = require('events');
-var assert = require('assert');
+const EventEmitter = require('events');
+const ModuleDef = require('server/modules/module_def');
+const assert = require('assert');
+
+class EmptyModuleDef extends ModuleDef {
+  constructor() {
+    super('_empty');
+    // TODO(applmak): ^ this hacky.
+    // However, b/c of the hack, this module will never become valid.
+    this.whenLoadedPromise = Promise.resolve(this);
+  }
+}
 
 class ModuleLibrary extends EventEmitter {
   constructor() {
     super();
     
-    // Map of name -> ModuleDef
-    this.modules = {};
+    this.reset();
   }
   register(def) {
     assert(!(def.name in this.modules), 'Def ' + def.name + ' already exists!');
@@ -33,15 +42,9 @@ class ModuleLibrary extends EventEmitter {
     def.on('reloaded', () => {
       this.emit('reloaded', def);
     });
-	
-    if (def.name == 'solid') {
-      this.register(def.extend('_faded_out', '', '', {
-        color: 'black'
-      }));
-    }
   }
   reset() {
-    this.modules = {};
+    this.modules = {'_empty': new EmptyModuleDef};
   }
 }
 

--- a/server/modules/module_state_machine.js
+++ b/server/modules/module_state_machine.js
@@ -93,10 +93,10 @@ class ModuleStateMachine extends stateMachine.Machine {
     }
 
     // Tell the clients to stop.
-    this.context_.clients.forEach(c => c.nextModule(ModuleDef.emptyModule(), deadline, this.context_.geo));
+    this.context_.clients.forEach(c => c.nextModule('_empty', deadline, this.context_.geo));
     
     // Tell the server to stop.
-    this.context_.server.nextModule(ModuleDef.emptyModule(), deadline);
+    this.context_.server.nextModule('_empty', deadline);
 
     // Set us back to idle, awaiting further instructions.
     this.transitionTo(new IdleState);

--- a/server/modules/server_state_machine.js
+++ b/server/modules/server_state_machine.js
@@ -76,7 +76,7 @@ class IdleState extends stateMachine.State {
     }
   }
   nextModule(module, deadline) {
-    this.transition_(new PrepareState(new RunningModule(ModuleDef.emptyModule()), module, deadline));
+    this.transition_(new PrepareState(new RunningModule(library.modules['_empty']), module, deadline));
   }
 }
 


### PR DESCRIPTION
I broke this when I removed the 'stop' event from before.
This fix:
- Removes the super-duper hacky '_faded_out' module, which was based on having 'solid' in your playlist and so seems like an unreasonable burden.
- Introduces a slightly less hacky '_empty' module, which atm has special-casing in a couple of places based on the name. I've added TODOs to make this better.
- Always adds and removes a container in the client, even for invalid modules.
- Forces a constant background color for the container, which means that the compositor in the browser has a little more work to do, but also means that folks don't (technically) have to clear the screen and can count on its being black. This makes transitions to invalid modules fade correctly.
- Fix a bug when we fadeout so that we begin the fadeout asap, rather than 5 seconds into the future.