### PR TITLE
Drive SMs according to the playlist.

### DIFF
--- a/server/control.js
+++ b/server/control.js
@@ -17,6 +17,7 @@ limitations under the License.
 
 const debug = require('debug')('wall:control');
 const log = require('server/util/log');
+const wallGeometry = require('server/util/wall_geometry');
 
 // Basic server management hooks.
 // This is just for demonstration purposes, since the real server
@@ -98,7 +99,18 @@ class Control {
   }
 
   getLayout(req, res) {
-    res.json(this.layoutSM.getLayout());
+    const ret = {};
+    let info = this.layoutSM.getCurrentModuleInfo();
+    ret.partitions = this.layoutSM.getPartition().map((p, i) => {
+      return {
+        geo: p, 
+        state: info[i].state,
+        deadline: info[i].deadline
+      };
+    });
+    ret.wall = wallGeometry.getGeo();
+    
+    res.json(ret);
   }
 
   skip(req, res) {

--- a/server/modules/module_state_machine.js
+++ b/server/modules/module_state_machine.js
@@ -16,9 +16,7 @@ limitations under the License.
 'use strict';
 require('lib/promise');
 
-const ModuleDef = require('server/modules/module_def');
 const debug = require('debug')('wall:module_state_machine');
-const random = require('random-js')();
 const assert = require('lib/assert');
 
 const stateMachine = require('lib/state_machine');
@@ -56,11 +54,6 @@ class ModuleStateMachine extends stateMachine.Machine {
     // Forward errors from my child state machines to my listener.
     this.context_.server.setErrorListener(error => this.errorListener_(error));
     this.context_.clients.forEach(c => c.setErrorListener(error => this.errorListener_(error)));
-    this.setErrorListener(error => {
-      debug('Error in sub-sm, continuing playlist...');
-      // If an error occurs in any client or server, skip this module.
-      this.nextModule();
-    });
 
     this.reloadHandler = reloadedModule => {
       // If the module that was just reloaded is the same one that we are playing, we should reload it.
@@ -103,82 +96,39 @@ class ModuleStateMachine extends stateMachine.Machine {
   }
   
   newClient(clientInfo) {
-    if (!isDisplayInPoly(clientInfo.rect, this.context_.geo)) {
-      return false;
-    }
-
     let client = this.allClients_[clientInfo.socket.id];
     this.context_.clients.push(client);
     this.state.newClient(client, this.context_.geo);
-    return true;
   }
   dropClient(id) {
     let client = this.allClients_[id];
     
     let i = this.context_.clients.findIndex(c => c === client);
-    
-    if (i == -1) {
-      return false;
-    }
+
+    assert(i != -1, `Told to drop client ${id} but couldn't find it in my client list!`);
 
     this.context_.clients.splice(i, 1);
-
-    return true;
   }
-  loadPlaylist(layout, deadline) {
-    if (monitor.isEnabled()) {
-      monitor.update({module: {
-        time: time.now(),
-        event: 'load-playlist',
-        deadline: deadline
-      }});
-    }
-    
-    // Copy the playlist & shuffle.
-    let playlist = Array.from(layout.modules);
-    random.shuffle(playlist);
-    
-    // Load the modules referenced in this playlist.
-    Promise.allSettled(playlist.map(m => library.modules[m].whenLoadedPromise)).done(results => {
-      // TODO(applmak): Omitting bad modules at THIS point is a weird choice.
-      // We should do it earlier, perhaps at load time.
-      
-      // Check to see if any modules were rejected. If so, remove them from the 
-      // playlist before requesting the state machine to execute anything.
-      let filteredPlaylist = playlist.filter(
-          (module, index) => results[index].status == 'resolved');
-      if (filteredPlaylist.length > 0) {
-        this.transitionTo(new DisplayState(filteredPlaylist, layout, deadline));
-      } else {
-        throw new Error('Playlist has no modules!');
-      }
-    });
-  }
-  playModule(moduleName) {
+  
+  playModule(moduleName, timeToStartDisplay) {
     if (monitor.isEnabled()) {
       monitor.update({module: {
         time: time.now(),
         event: moduleName
       }});
     }
-    
     if (!this.reloadHandlerInstalled_) {
       library.on('reloaded', this.reloadHandler);
       this.reloadHandlerInstalled_ = true;
     }
     
-    // Note: this will throw if the module is not in the current playlist, as
-    // we have no def for it.
-    // TODO(applmak): Handle this better.
-    this.state.playModule(moduleName);
-  }
-  nextModule() {
-    this.state.nextModule();
+    
+    this.state.playModule(moduleName, timeToStartDisplay);
   }
   getGeo() {
     return this.context_.geo;
   }
-  getDeadlineOfNextTransition() {
+  getDeadline() {
     return this.state.getDeadline();
   }
 }
@@ -195,12 +145,8 @@ class IdleState extends stateMachine.State {
     this.transition_ = transition;
   }
   newClient(client) {}
-  playModule(moduleName) {
-    throw new Error(`No module named ${moduleName}`);
-  }
-  nextModule() {
-    // ... no next module!
-    throw new Error('No next module!');
+  playModule(moduleName, timeToStartDisplay) {
+    this.transition_(new DisplayState(moduleName, timeToStartDisplay));
   }
   getCurrentModuleName() {
     return '';
@@ -211,108 +157,49 @@ class IdleState extends stateMachine.State {
 }
 
 class DisplayState extends stateMachine.State {
-  constructor(playlist, layout, deadline, index = 0) {
+  constructor(moduleName, timeToStartDisplay) {
     super();
 
-    this.layout_ = layout;
-    this.playlist_ = playlist;
+    // This current module we are attempting to show.
+    this.moduleName_ = moduleName;
     
-    // Index cannot be out of bounds.
-    assert(index < playlist.length);
-    this.index_ = index;
-
-    this.displayDuration_ = this.layout_.moduleDuration * 1000;
-    this.deadline_ = deadline;
-    
-    // The current module we are attempting to show or showing.
-    this.module_ = playlist[index];
-    
-    this.timer_ = null;
+    // The time that we should begin to show the new module.
+    this.timeToStartDisplay_ = timeToStartDisplay;
   }
   enter(transition, context) {
     this.transition_ = transition;
     
-    debug(`Displaying ${this.module_} starting at ${this.deadline_}`);
+    debug(`Displaying ${this.moduleName_} starting at ${this.timeToStartDisplay_}`);
     
     if (monitor.isEnabled()) {
       monitor.update({module: {
         time: time.now(),
-        deadline: this.deadline_,
+        name: this.moduleName_,
         state: this.getName(),
       }});
     }
     
     // Tell the server to transition to this new module.
-    context.server.playModule(this.module_, this.deadline_, context.geo);
-    
-    // Be prepared for the server to go to error state.
-    let errorHandler = () => {
-      if (!this.timer_) {
-        // We're leaving the state anyway.
-        return;
-      }
-      if (context.server.state.getName() == 'ErrorState') {
-        // We transitioned to the error state!
-        debug(`Error encountered in server module ${this.module_}`);
-        // Allow the server to transition internally (back to idle).
-        context.server.restartMachineAfterError();
-        
-        // Remove the module from the list.
-        this.playlist_.splice(this.index_, 1);
-        
-        if (this.playlist_.length == 0) {
-          throw new Error('No modules left in playlist!');
-        }
-
-        // Go to the next module in 5 seconds.
-        let nextModuleIndex = this.index_ % this.playlist_.length;
-        this.transition_(new DisplayState(this.playlist_, this.layout_, time.inFuture(5000), nextModuleIndex));
-      } else {
-        context.server.getTransitionPromise().then(errorHandler);
-      }
-    };
-    context.server.getTransitionPromise().then(errorHandler);
+    context.server.playModule(this.moduleName_, this.timeToStartDisplay_, context.geo);
 
     // Tell each client to transition to the module.
-    context.clients.forEach(client => client.playModule(this.module_, this.deadline_, context.geo));
-
-    // Transition to the next thing in the playlist when the deadline + the 
-    // duration pass.
-    let durationBeforePrepare = Math.max(this.displayDuration_ - 5000, 0);
-    let prepareDeadline = this.deadline_ + durationBeforePrepare;
-    debug('Waiting until', this.deadline_, prepareDeadline);
-    this.timer_ = setTimeout(() => this.nextModule(), time.until(prepareDeadline));
-  }
-  exit() {
-    clearTimeout(this.timer_);
-    // Signal that we are leaving.
-    this.timer_ = null;
+    context.clients.forEach(client => client.playModule(this.moduleName_, this.timeToStartDisplay_, context.geo));
+    
+    // Wait here until we're told to do something else.
   }
   newClient(client, geo) {
     // Tell the new guy to load the next module NOW.
-    client.playModule(this.module_, this.deadline_, geo);
+    // We'll presume that this guy arrived way after our coordinating time, so we'll tell him to switch now.
+    client.playModule(this.moduleName_, this.timeToStartDisplay_, geo);
   }
-  playModule(moduleName) {
-    // Find what index that is.
-    var index = this.playlist_.findIndex(m => m == moduleName);
-    if (index == -1) {
-      throw new Error(`Unable to find module ${moduleName} in the playlist!`);
-    }
-    this.transition_(new DisplayState(this.playlist_, this.layout_, time.inFuture(0), index));
-  }
-  nextModule() {
-    if (this.playlist_.length == 0) {
-      throw new Error('No modules left in playlist!');
-    }
-    let nextModuleIndex = (this.index_ + 1) % this.playlist_.length;
-    debug(`Begin preparing to transition to ${this.playlist_[nextModuleIndex]} (item ${nextModuleIndex} of ${this.playlist_.length})`);
-    this.transition_(new DisplayState(this.playlist_, this.layout_, time.now(), nextModuleIndex));
+  playModule(moduleName, timeToStartDisplay) {
+    this.transition_(new DisplayState(moduleName, timeToStartDisplay));
   }
   getCurrentModuleName() {
-    return this.module_;
+    return this.moduleName_;
   }
   getDeadline() {
-    return this.deadline_ + this.displayDuration_;
+    return this.timeToStartDisplay_;
   }
 }
 

--- a/server/modules/module_ticker.js
+++ b/server/modules/module_ticker.js
@@ -42,12 +42,14 @@ tick();
 
 module.exports = {
   add: function(module, globals) {
-    modulesToTick.push(module);
-    debug(
-        'Add: We are now ticking ' + modulesToTick.length + ' modules:',
-        modulesToTick.map((m) => m.moduleDef.name).join(', '));
-    if (modulesToTick.length > 2) {
-      debug('FAILED!');
+    if (module.instance) {
+      modulesToTick.push(module);
+      debug(
+          'Add: We are now ticking ' + modulesToTick.length + ' modules:',
+          modulesToTick.map((m) => m.moduleDef.name).join(', '));
+      if (modulesToTick.length > 2) {
+        debug('FAILED!');
+      }
     }
   },
   remove: function(module) {
@@ -57,7 +59,7 @@ module.exports = {
         return false;
       }
       return true;
-    })
+    });
     debug('Remove: We are now ticking ' + modulesToTick.length + ' modules',
         modulesToTick.map((m) => m.moduleDef.name).join(', '));
   }

--- a/server/modules/playlist_driver.js
+++ b/server/modules/playlist_driver.js
@@ -1,0 +1,87 @@
+/* Copyright 2015 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+'use strict';
+
+const monitor = require('server/monitoring/monitor');
+const random = require('random-js')();
+const time = require('server/util/time');
+const wallGeometry = require('server/util/wall_geometry');
+
+const driveStateMachine = (playlist, layoutSM) => {
+  const nextLayout = layoutIndex => {
+    // Show this layout next:
+    let layout = playlist[layoutIndex];
+    let partition = wallGeometry.partitionGeo(layout.maxPartitions);
+
+    // The time that we'll switch to a new layout.
+    let newLayoutTime = time.inFuture(layout.duration * 1000);
+
+    if (monitor.isEnabled()) {
+      monitor.update({playlist: {
+        time: time.now(),
+        event: `change layout`,
+        deadline: newLayoutTime
+      }});
+    }
+
+    layoutSM.setPartition(partition).then(() => {
+      // Shuffle the module list for each partition:
+      let modulesPerPartition = partition.map(() => {
+        let modules = Array.from(layout.modules);
+        random.shuffle(modules);
+        return modules;
+      });
+
+      const nextModule = moduleIndex => {
+        let timer;
+        layoutSM.setErrorListener(error => {
+          // Stop normal advancement.
+          clearTimeout(timer);
+          nextModule((moduleIndex + 1) % modulesPerPartition[0].length);
+        });
+
+        // The time that we'll switch to the next module.
+        let newModuleTime = time.inFuture(layout.moduleDuration * 1000);
+
+        // Tell each partition to play the next module in the list.
+        modulesPerPartition.forEach((modules, index) => {
+          layoutSM.playModule(index, modules[moduleIndex]);
+        });
+
+        if (monitor.isEnabled()) {
+          monitor.update({playlist: {
+            time: time.now(),
+            event: `change module`,
+            deadline: Math.min(newModuleTime, newLayoutTime)
+          }});
+        }
+
+        // Now, in so many seconds, we'll need to switch to another module or another layout. How much time do we
+        // have?
+        timer = (newLayoutTime < newModuleTime) ?
+          setTimeout(() => nextLayout((layoutIndex + 1) % playlist.length), time.until(newLayoutTime)) :
+          setTimeout(() => nextModule((moduleIndex + 1) % modulesPerPartition[0].length), time.until(newModuleTime));
+      };
+
+      Promise.all(layout.modules.map(m => m.whenLoadedPromise)).then(() => nextModule(0));
+    });
+  };
+  nextLayout(0);
+};
+
+module.exports = {
+  driveStateMachine
+};

--- a/server/server.js
+++ b/server/server.js
@@ -20,6 +20,7 @@ const commandLineArgs = require('command-line-args');
 const commandLineUsage = require('command-line-usage');
 const debug = require('debug')('wall:server');
 
+const playlistDriver = require('server/modules/playlist_driver');
 const game = require('./game/game');
 const network = require('server/network/network');
 const LayoutStateMachine = require('server/modules/layout_state_machine');
@@ -125,10 +126,6 @@ peerServer.on('disconnect', function(id) {
 
 network.openWebSocket(server);
 
-debug('Running playlist of ' + playlist.length + ' items');
-
-layoutSM.setPlaylist(playlist);
-
 network.on('new-client', function(client) {
   layoutSM.newClient(client);
 });
@@ -140,3 +137,6 @@ network.on('lost-client', function(id) {
 if (flags.enable_monitoring) {
   monitor.enable();
 }
+
+debug('Running playlist of ' + playlist.length + ' items');
+playlistDriver.driveStateMachine(playlist, layoutSM);


### PR DESCRIPTION
This moves all of the logic for moving from one module to another, or one layout to another outside of the state machines themselves. This is pretty major change from the way that we've done all such transitions up to this point, and so this code should be treated very suspiciously. It finally allows us to have more complicated logic around how the playlist works, because rather than needing to encoding the understanding of the playlist format into the SMs, which is an encapsulation violation, we can stick all of that logic in an external 'playlist driver' that knows about how to understand the playlist format. Finally, we have a chance of making that driver able to change things based on time of day, some calendar-based schedule, or really, anything else, without having to modify the SMs themselves, which are already too complicated.

Because this changes the API of the two main state machines, layout and module, we also need to update their main callsites: control, where we match the current API that the status page expects; and server, where we invoke the new playlist driver to drive the machines.

One major last piece of work that we need to do to really make our modules smarter is to introduce the notion of a module being able to send an event denoting that it is "finished" for modules that have a certain built-in duration, such as those that play videos. This could be implemented as a promise or simply as an event that the SMs emit and the playlist driver listens for in order to proceed to the next module.

Another janitorial task is to fixup all of the nouns called "deadline" or "time" to be more specific about what these times are referring to. I think if we request a module to play for 10 seconds that we aren't exactly letting the module play for 10 seconds, and this bug is super-hard to track down given our reuse of those two words all over the place.