### PR TITLE
Get shell scripts ready for cron.

### DIFF
--- a/demo_modules/wind/bin/fetch_forecast.sh
+++ b/demo_modules/wind/bin/fetch_forecast.sh
@@ -1,19 +1,35 @@
 #!/bin/bash
 
 # Requires grib2json which is built on java. You can install a CLI-wrapper wth
-# npm, but you must have a JRE installed.  $JAVA_HOME must be set as an
-# environment variable.
+# npm, but you must have a JRE installed. This assumes that java is available on
+# your path.
 #
 # $ npm install -g weacast-grib2json
 #
 
-# Replace this with a proper system tmp directory.
-mkdir -p ./tmp
+# Portable secure tmp directory:
+# https://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x
+TMPDIR=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
+
+if [[ -d $1 ]];then
+  OUT=$1
+else
+  OUT="../../../demo_assets"
+fi
+
+echo "Downloading forecast data to: $OUT"
 
 # Forecasts are released every 6 hours UTC time. Start with 6 hours ago so we
 # can be sure it is already available.
-DATE=`date -u -v-6H +%Y%m%d`
-HOUR=`date -u -v-6H +%H`
+if date --version >/dev/null 2>&1 ; then
+  # GNU date on linux.
+  DATE=`date -u -d '-6 hours' +%Y%m%d`
+  HOUR=`date -u -d '-6 hours' +%H`
+else
+  # BSD date on mac.
+  DATE=`date -u -v-6H +%Y%m%d`
+  HOUR=`date -u -v-6H +%H`
+fi
 
 # Reduce to the nearest 6 our block with integer division.
 HOUR=`expr \( ${HOUR} / 6 \) \* 6`
@@ -22,12 +38,17 @@ HOUR=`expr \( ${HOUR} / 6 \) \* 6`
 HOUR=`printf "%02d" ${HOUR}`
 
 # Fetch the forecast.
-curl "http://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_1p00.pl?file=gfs.t${HOUR}z.pgrb2.1p00.f000&lev_10_m_above_ground=on&var_UGRD=on&var_VGRD=on&leftlon=0&rightlon=360&toplat=90&bottomlat=-90&dir=%2Fgfs.${DATE}${HOUR}" -o tmp/gfs.t${HOUR}z.pgrb2.1p00.f000
+curl "http://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_1p00.pl?file=gfs.t${HOUR}z.pgrb2.1p00.f000&lev_10_m_above_ground=on&var_UGRD=on&var_VGRD=on&leftlon=0&rightlon=360&toplat=90&bottomlat=-90&dir=%2Fgfs.${DATE}${HOUR}" -o $TMPDIR/gfs.t${HOUR}z.pgrb2.1p00.f000
+
+PREFIX=`npm config get prefix`
 
 # Convert to json.
-/usr/local/lib/node_modules/weacast-grib2json/bin/grib2json -d -n \
-  -o 'tmp/current-wind-surface-level-gfs-1.0.json' \
-  tmp/gfs.t${HOUR}z.pgrb2.1p00.f000
+java -Xmx512M -jar $PREFIX/lib/node_modules/weacast-grib2json/bin/grib2json.jar -d -n \
+  -o "$TMPDIR/current-wind-surface-level-gfs-1.0.json" \
+  $TMPDIR/gfs.t${HOUR}z.pgrb2.1p00.f000
 
 # Make it available.
-cp tmp/current-wind-surface-level-gfs-1.0.json ../../../demo_assets
+cp $TMPDIR/current-wind-surface-level-gfs-1.0.json $OUT
+
+# Remove tmp dir.
+rm -rf $TMPDIR

--- a/demo_modules/wind/bin/fetch_mapdata.sh
+++ b/demo_modules/wind/bin/fetch_mapdata.sh
@@ -1,34 +1,48 @@
 #!/bin/bash
 
-# Replace this with a proper system tmp directory.
-mkdir -p ./tmp
+# Requires ogr2ogr part of the gdal framework to be available in PATH.
+# For mac, install 2.1 complete from http://www.kyngchaos.com/software:frameworks
+# Add /Library/Frameworks/GDAL.framework/Versions/Current/Programs to
+# your $PATH.
+# On ubuntu:  apt-get install gdal-bin
+
+TMPDIR=`mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir'`
+
+if [[ -d $1 ]];then
+  OUT=$1
+else
+  OUT="../../../demo_assets"
+fi
+
+echo "Downloading map data to: $OUT"
 
 # Get the map data
-curl -o 'tmp/ne_50m_admin_0_countries.zip' \
+curl -o "$TMPDIR/ne_50m_admin_0_countries.zip" \
   'http://naciscdn.org/naturalearth/50m/cultural/ne_50m_admin_0_countries.zip'
 
-curl -o 'tmp/ne_50m_lakes.zip' \
+curl -o "$TMPDIR/ne_50m_lakes.zip" \
   'http://naciscdn.org/naturalearth/50m/physical/ne_50m_lakes.zip'
 
-pushd tmp
+pushd $TMPDIR
 unzip ne_50m_admin_0_countries.zip
 unzip ne_50m_lakes.zip
 popd
 
 # Extract relavent features.
-# Requires ogr2ogr part of the gdal framework.
-# For mac, install 2.1 complete from http://www.kyngchaos.com/software:frameworks
-/Library/Frameworks/GDAL.framework/Versions/Current/Programs/ogr2ogr \
+ogr2ogr \
   -f GeoJSON \
   -where "continent = 'North America' OR continent = 'South America'" \
-  tmp/americas.json \
-  tmp/ne_50m_admin_0_countries.shp
+  $TMPDIR/americas.json \
+  $TMPDIR/ne_50m_admin_0_countries.shp
 
-/Library/Frameworks/GDAL.framework/Versions/Current/Programs/ogr2ogr \
+ogr2ogr \
   -f GeoJSON \
-  tmp/lakes.json \
-  tmp/ne_50m_lakes.shp
+  $TMPDIR/lakes.json \
+  $TMPDIR/ne_50m_lakes.shp
 
 # Copy to assets.
-cp tmp/americas.json ../../../demo_assets
-cp tmp/lakes.json ../../../demo_assets
+cp $TMPDIR/americas.json $OUT
+cp $TMPDIR/lakes.json $OUT
+
+# Remove tmp dir.
+rm -rf $TMPDIR


### PR DESCRIPTION
- Allow output dir to be specified on command line and use a real tmpdir.
- Make shell scripts more portable.