### PR TITLE
Module-relative imports

### DIFF
--- a/demo_modules/slideshow/falling_display.js
+++ b/demo_modules/slideshow/falling_display.js
@@ -15,11 +15,12 @@ limitations under the License.
 
 'use strict';
 const debug = require('debug');
-const interfaces = require('demo_modules/slideshow/interfaces');
 const _ = require('underscore');
 const assert = require('lib/assert');
 const wallGeometry = require('wallGeometry');
 const network = require('network');
+
+const interfaces = require('./interfaces');
 
 // FALLING DISPLAY STRATEGY
 // Elements fall from the top of the wall to the bottom at the constant speed

--- a/demo_modules/slideshow/fullscreen_display.js
+++ b/demo_modules/slideshow/fullscreen_display.js
@@ -15,11 +15,12 @@ limitations under the License.
 
 'use strict';
 const debug = require('debug');
-const interfaces = require('demo_modules/slideshow/interfaces');
 const _ = require('underscore');
 const assert = require('lib/assert');
 const wallGeometry = require('wallGeometry');
 const network = require('network');
+
+const interfaces = require('./interfaces');
 
 // FULLSCREEN DISPLAY STRATEGY
 // This display strategy shows a single element per screen, updating at a rate

--- a/demo_modules/slideshow/load_from_drive.js
+++ b/demo_modules/slideshow/load_from_drive.js
@@ -15,8 +15,9 @@ limitations under the License.
 
 'use strict';
 const debug = require('debug');
-const interfaces = require('demo_modules/slideshow/interfaces');
 const serverRequire = require('lib/server_require');
+
+const interfaces = require('./interfaces');
 
 // LOAD FROM DRIVE STRATEGY
 // Here, we specify the server & client strategies that can load images from a

--- a/demo_modules/slideshow/load_from_flickr.js
+++ b/demo_modules/slideshow/load_from_flickr.js
@@ -16,9 +16,10 @@ limitations under the License.
 'use strict';
 const debug = require('debug');
 const querystring = require('querystring');
-const interfaces = require('demo_modules/slideshow/interfaces');
 const serverRequire = require('lib/server_require');
 const assert = require('lib/assert');
+
+const interfaces = require('./interfaces');
 
 // LOAD FROM FLICKR STRATEGY
 // Here, we specify the server & client strategies that can load images from a

--- a/demo_modules/slideshow/load_from_youtube.js
+++ b/demo_modules/slideshow/load_from_youtube.js
@@ -15,8 +15,9 @@ limitations under the License.
 
 'use strict';
 const debug = require('debug');
-const interfaces = require('demo_modules/slideshow/interfaces');
 const serverRequire = require('lib/server_require');
+
+const interfaces = require('./interfaces');
 
 // LOAD YOUTUBE PLAYLIST STRATEGY
 // Config:

--- a/demo_modules/slideshow/load_local.js
+++ b/demo_modules/slideshow/load_local.js
@@ -15,7 +15,8 @@ limitations under the License.
 
 'use strict';
 const debug = require('debug');
-const interfaces = require('demo_modules/slideshow/interfaces');
+
+const interfaces = require('./interfaces');
 
 // LOAD LOCAL FILES STRATEGY
 // This loading strategy knows how to load both images and videos from the local file

--- a/demo_modules/slideshow/slideshow.js
+++ b/demo_modules/slideshow/slideshow.js
@@ -31,13 +31,13 @@ const wallGeometry = require('wallGeometry');
 const debug = require('debug');
 const network = require('network');
 
-const LoadFromDriveStrategy = require('demo_modules/slideshow/load_from_drive');
-const LoadFromYouTubePlaylistStrategy = require('demo_modules/slideshow/load_from_youtube');
-const LoadLocalStrategy = require('demo_modules/slideshow/load_local');
-const LoadFromFlickrStrategy = require('demo_modules/slideshow/load_from_flickr');
+const LoadFromDriveStrategy = require('./load_from_drive');
+const LoadFromYouTubePlaylistStrategy = require('./load_from_youtube');
+const LoadLocalStrategy = require('./load_local');
+const LoadFromFlickrStrategy = require('./load_from_flickr');
 
-const FullscreenDisplayStrategy = require('demo_modules/slideshow/fullscreen_display');
-const FallingDisplayStrategy = require('demo_modules/slideshow/falling_display');
+const FullscreenDisplayStrategy = require('./fullscreen_display');
+const FallingDisplayStrategy = require('./falling_display');
 
 // DISPATCH TABLES
 // These methods convert a load or display config to specific server or client

--- a/demo_modules/wind/forecast_grid.js
+++ b/demo_modules/wind/forecast_grid.js
@@ -17,9 +17,9 @@ limitations under the License.
 // at https://earth.nullschool.net and its open source code:
 // https://github.com/cambecc/earth.
 
-const util = require('demo_modules/wind/util');
 const interpolateLib = require('lib/interpolate');
 
+const util = require('./util');
 const floorMod = util.floorMod;
 const isValue = util.isValue;
 

--- a/demo_modules/wind/particle_field.js
+++ b/demo_modules/wind/particle_field.js
@@ -17,7 +17,7 @@ limitations under the License.
 // at https://earth.nullschool.net and its open source code:
 // https://github.com/cambecc/earth.
 
-const color = require('demo_modules/wind/color');
+const color = require('./color');
 
 const MIN_WIND_RGB = 160;
 const INTENSITY_SCALE_STEP = 5;

--- a/demo_modules/wind/vector_field.js
+++ b/demo_modules/wind/vector_field.js
@@ -17,10 +17,11 @@ limitations under the License.
 // at https://earth.nullschool.net and its open source code:
 // https://github.com/cambecc/earth.
 
-const color = require('demo_modules/wind/color');
 const d3 = require('d3');
-const util = require('demo_modules/wind/util');
 const wallGeometry = require('wallGeometry');
+
+const color = require('./color');
+const util = require('./util');
 
 const floorMod = util.floorMod;
 const isValue = util.isValue;

--- a/demo_modules/wind/wind.js
+++ b/demo_modules/wind/wind.js
@@ -20,9 +20,9 @@ const globalWallGeometry = require('globalWallGeometry');
 const wallGeometry = require('wallGeometry');
 const network = require('network');
 
-const ForecastGrid = require('demo_modules/wind/forecast_grid');
-const VectorField = require('demo_modules/wind/vector_field');
-const ParticleField = require('demo_modules/wind/particle_field');
+const ForecastGrid = require('./forecast_grid');
+const ParticleField = require('./particle_field');
+const VectorField = require('./vector_field');
 
 const ROTATEX = 100;
 const ROTATEY = -400;


### PR DESCRIPTION
They already worked properly on the client, but the server only supported
package-relative imports. Here we add path rewiting on the server for relative
paths and update all uses of module-relative imports to do them with relative
paths instead.

First step to fixing #103.