### PR TITLE
Add flags to enable HTTPS and to require client certs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4419,6 +4419,11 @@
         "statuses": "1.4.0"
       }
     },
+    "https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q="
+    },
     "https-proxy-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express": "^4.16.2",
     "google-drive-sheets": "^1.3.0",
     "googleapis": "^2.1.6",
+    "https": "^1.0.0",
     "jsfeat": "^0.0.8",
     "node-fetch": "^1.7.3",
     "noisejs": "^2.1.0",


### PR DESCRIPTION
This does nothing by default. If use_https is set, this enables HTTPS for incoming client connections using the certificates in the certs/ directory. If require_client_cert is set, the server rejects any connections from clients not using a certificate trusted by the server.