### PR TITLE
Replace three with three-full for a better threejs experience.

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -30,7 +30,7 @@ requirejs.config({
     'querystring': 'sys/simple-query-string/src/simplequerystring',
     'socket.io' : 'sys/socket.io-client/dist/socket.io',
     'strict-uri-encode': 'sys/strict-uri-encode/index',
-    'three' : 'sys/three/three',
+    'three-full' : 'sys/three-full/builds/Three.amd',
     'underscore' : 'sys/underscore/underscore',
     'vm-shim' : 'sys/vm-shim/vm-shim',
   },
@@ -39,7 +39,6 @@ requirejs.config({
   shim : {
     'noisejs': {exports: 'Noise'},
     'peer': {exports: 'Peer'},
-    'three': {exports: 'THREE'},
     'vm-shim': {exports: 'vm'}
   }
 });

--- a/client/surface/threejs_surface.js
+++ b/client/surface/threejs_surface.js
@@ -15,17 +15,17 @@ limitations under the License.
 
 define(function(require) {
   'use strict';
-  var Surface = require('client/surface/surface');
-  var THREE = require('three');
+  const Surface = require('client/surface/surface');
+  const Three = require('three-full');
 
   var ThreeJsSurface = function(container, wallGeometry, properties) {
     Surface.call(this, container, wallGeometry);
-    this.renderer = new THREE.WebGLRenderer(properties);
+    this.renderer = new Three.WebGLRenderer(properties);
     this.renderer.setSize(this.container.offsetWidth, this.container.offsetHeight);
     container.appendChild(this.renderer.domElement);
 
-    this.camera = new THREE.PerspectiveCamera(45, this.wallRect.w / this.wallRect.h, 0.1, 1000);
-    this.scene = new THREE.Scene;
+    this.camera = new Three.PerspectiveCamera(45, this.wallRect.w / this.wallRect.h, 0.1, 1000);
+    this.scene = new Three.Scene;
 
     this.camera.setViewOffset(
         this.wallRect.w, this.wallRect.h,

--- a/demo_modules/particles/particles.js
+++ b/demo_modules/particles/particles.js
@@ -107,15 +107,15 @@ class ParticleEmitter {
     var misc = new Float32Array(MAX_PARTICLES_PER_CLIENT * 4);
 
     // While we are here, also allocate memory in the GPU for these.
-    var posVelBuffer = new THREE.BufferAttribute(posVel, 4).setDynamic(true);
-    var miscBuffer = new THREE.BufferAttribute(misc, 4).setDynamic(true);
+    var posVelBuffer = new Three.BufferAttribute(posVel, 4).setDynamic(true);
+    var miscBuffer = new Three.BufferAttribute(misc, 4).setDynamic(true);
 
-    this.geometry = new THREE.BufferGeometry();
+    this.geometry = new Three.BufferGeometry();
     this.geometry.setDrawRange(0, 0);
     this.geometry.addAttribute('posVel', posVelBuffer);
     this.geometry.addAttribute('misc', miscBuffer);
     
-    // Store the THREE versions of those attribute buffers for later mutation.
+    // Store the Three versions of those attribute buffers for later mutation.
     this.posVelBuffer_ = this.geometry.getAttribute('posVel');
     this.miscBuffer_ = this.geometry.getAttribute('misc');
     
@@ -126,7 +126,7 @@ class ParticleEmitter {
     // We don't always have a fixed number of active particles. We'll use an
     // index buffer to mention the particles we want to change.
     var indices = new Uint16Array(MAX_PARTICLES_PER_CLIENT);
-    this.geometry.setIndex(new THREE.BufferAttribute(indices, 1).setDynamic(true));
+    this.geometry.setIndex(new Three.BufferAttribute(indices, 1).setDynamic(true));
     this.indexBuffer_ = this.geometry.getIndex();
     // We'll fill out the index buffer with our reset index -1, indicating that
     // we have no particle here just as of yet.
@@ -283,7 +283,7 @@ class ParticleEmitter {
 
 class ParticlesClient extends ModuleInterface.Client {
   willBeShownSoon(container, deadline) {
-    const THREE = require('three');
+    const Three = require('three-full');
     this.noise = new Noise(deadline % 1);
     const ThreeJsSurface = require('client/surface/threejs_surface');
     this.surface = new ThreeJsSurface(container, wallGeometry);
@@ -307,12 +307,12 @@ class ParticlesClient extends ModuleInterface.Client {
     this.debugCanvas.canvas.style.zIndex = '1000';
     this.peer_ = null;
     this.emitter = new ParticleEmitter();
-    
-    var mat = new THREE.ShaderMaterial({
+
+    var mat = new Three.ShaderMaterial({
       transparent: true,
       depthWrite: false,
       uniforms: {},
-      blending: THREE.AdditiveBlending,
+      blending: Three.AdditiveBlending,
       vertexShader: `
         precision highp float;
         #define FLOAT_MAX  1.70141184e38
@@ -374,11 +374,11 @@ class ParticlesClient extends ModuleInterface.Client {
       `
     });
     
-    this.points = new THREE.Points(this.emitter.geometry, mat);
+    this.points = new Three.Points(this.emitter.geometry, mat);
     this.points.frustumCulled = false;
     this.surface.scene.add(this.points);
 
-    this.surface.camera = new THREE.OrthographicCamera(
+    this.surface.camera = new Three.OrthographicCamera(
         this.surface.virtualRect.x, this.surface.virtualRect.x+this.surface.virtualRect.w,
         this.surface.virtualRect.y, this.surface.virtualRect.y+this.surface.virtualRect.h,
         -1, 1);

--- a/demo_modules/threejs_test/threejs_test.js
+++ b/demo_modules/threejs_test/threejs_test.js
@@ -27,14 +27,14 @@ class ThreeJsTestClient extends ModuleInterface.Client {
   }
 
   willBeShownSoon(container, deadline) {
-    const THREE = require('three');
+    const Three = require('three-full');
     this.startTime = deadline;
     const ThreeJsSurface = require('client/surface/threejs_surface');
     this.surface = new ThreeJsSurface(container, wallGeometry);
 
-    var geometry = new THREE.BoxGeometry(3, 3, 3);
-    var material = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
-    this.cube = new THREE.Mesh(geometry, material);
+    var geometry = new Three.BoxGeometry(3, 3, 3);
+    var material = new Three.MeshBasicMaterial({ color: 0x00ff00 });
+    this.cube = new Three.Mesh(geometry, material);
     this.surface.scene.add(this.cube);
 
     this.surface.camera.position.set(0, 0, 5);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chicago-brick",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7640,8 +7640,16 @@
         "js-binarypack": "0.0.9",
         "opencollective": "^1.0.3",
         "opencollective-postinstall": "^2.0.0",
-        "reliable": "git+https://github.com/michelle/reliable.git#f09ba29d57a05beaa07990171f3fe7b746587aaa",
         "webrtc-adapter": "^6.3.2"
+      },
+      "dependencies": {
+        "reliable": {
+          "version": "git+https://github.com/michelle/reliable.git#f09ba29d57a05beaa07990171f3fe7b746587aaa",
+          "from": "git+https://github.com/michelle/reliable.git#f09ba29d57a05beaa07990171f3fe7b746587aaa",
+          "requires": {
+            "js-binarypack": "0.0.9"
+          }
+        }
       }
     },
     "pend": {
@@ -8289,13 +8297,6 @@
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
         }
-      }
-    },
-    "reliable": {
-      "version": "git+https://github.com/michelle/reliable.git#f09ba29d57a05beaa07990171f3fe7b746587aaa",
-      "from": "git+https://github.com/michelle/reliable.git",
-      "requires": {
-        "js-binarypack": "0.0.9"
       }
     },
     "repeat-element": {
@@ -9214,10 +9215,10 @@
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
       "dev": true
     },
-    "three": {
-      "version": "0.72.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.72.0.tgz",
-      "integrity": "sha1-rE65X9TlsVnA/6u2CWF/7JCjNrI="
+    "three-full": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/three-full/-/three-full-11.3.2.tgz",
+      "integrity": "sha512-0qv9kLe2bp1ksV3mgjyzWtIBO//U19+RzoyAuSGkSKKYF0M3zxAwWU5L6rRhVj6L/GGlbUb4EHMa8QhcW8/Rtw=="
     },
     "throttleit": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "simple-query-string": "^1.3.2",
     "socket.io": "^1.3.5",
     "socket.io-client": "^1.3.5",
-    "three": "^0.72.0",
+    "three-full": "^11.3.2",
     "underscore": "^1.9.1"
   },
   "pre-commit": [


### PR DESCRIPTION
Update the dep, the client config mapping, threejs surface, and demos.
The three-full package includes lots of the utilities and extras used by the examples and demos, which should be useful for building new wall modules.
Tested locally with threejs_test module.