### PR TITLE
Keeping the certs directory out of the repo.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ demo_assets/wind-*.json
 .DS_STORE
 npm-debug.log
 package-lock.json
+certs


### PR DESCRIPTION
Certs should eventually be stored somewhere other than development boxes, but for the time being I'd like to keep them from being accidentally rolled into a commit.