### PR TITLE
Support separate client/server modules.

### DIFF
--- a/demo_modules/split_modules_example/brick.json
+++ b/demo_modules/split_modules_example/brick.json
@@ -1,0 +1,7 @@
+{
+  "name": "split_modules_example",
+  "client_path": "./hello_world_client.js",
+  "server_path": "./hello_world_server.js",
+  "title": "A \"Mandelbrot\" demo",
+  "author": "Matt Handley"
+}

--- a/demo_modules/split_modules_example/hello_world_client.js
+++ b/demo_modules/split_modules_example/hello_world_client.js
@@ -1,0 +1,94 @@
+/* Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+const register = require('register');
+const ModuleInterface = require('lib/module_interface');
+const debug = require('debug');
+const network = require('network');
+
+class HelloWorldClient extends ModuleInterface.Client {
+  constructor(config) {
+    super();
+
+    debug('Hello, world!', config);
+    this.color = config.color;
+    this.nextColor = null;
+    this.nextColorTime = 0;
+    this.image = null;
+    this.surface = null;
+
+    var client = this;
+    network.on('color', function handleColor(data) {
+      debug('handle color', data);
+      client.nextColor = data.color;
+      client.nextColorTime = data.time;
+    });
+  }
+
+  finishFadeOut() {
+    if (this.surface) {
+      this.surface.destroy();
+    }
+  }
+
+  willBeShownSoon(container, deadline) {
+    const asset = require('client/asset/asset');
+
+    this.startTime = deadline;
+    const CanvasSurface = require('client/surface/canvas_surface');
+    const wallGeometry = require('wallGeometry');
+    this.surface = new CanvasSurface(container, wallGeometry);
+    this.canvas = this.surface.context;
+
+    // Load the image asset.
+    var self = this;
+    return new Promise(function(resolve, reject) {
+      self.image = new Image;
+      self.image.onload = resolve;
+      self.image.src = asset('fractal.gif');
+    });
+  }
+
+  draw(time, delta) {
+    if (this.nextColorTime && this.nextColorTime < time) {
+      this.color = this.nextColor;
+      this.nextColorTime = 0;
+    }
+
+    this.canvas.fillStyle = 'black';
+    this.canvas.fillRect(0, 0, this.surface.virtualRect.w, this.surface.virtualRect.h);
+
+    this.canvas.fillStyle = 'white';
+
+    this.surface.pushOffset();
+    var x = Math.cos(time * Math.PI / 2000) * 100;
+    var y = Math.sin(time * Math.PI / 2000) * 100;
+    var cx = this.surface.wallRect.w / 2;
+    var cy = this.surface.wallRect.h / 2;
+
+    this.canvas.drawImage(this.image, cx + x - 50, cy + y - 50, 100, 100);
+
+    this.surface.popOffset();
+
+    this.canvas.fillStyle = this.color || 'white';
+    this.canvas.textAlign = 'center';
+    var fontHeight = Math.floor(this.surface.virtualRect.h / 10);
+    this.canvas.font = fontHeight + 'px Helvetica';
+    this.canvas.textBaseline = 'middle';
+    this.canvas.fillText('Time: ' + time.toFixed(1), this.surface.virtualRect.w / 2, this.surface.virtualRect.h / 2);
+  }
+}
+
+register(null, HelloWorldClient);

--- a/demo_modules/split_modules_example/hello_world_server.js
+++ b/demo_modules/split_modules_example/hello_world_server.js
@@ -1,0 +1,53 @@
+/* Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+const register = require('register');
+const ModuleInterface = require('lib/module_interface');
+const _ = require('underscore');
+const debug = require('debug');
+const network = require('network');
+
+class HelloWorldServer extends ModuleInterface.Server {
+  constructor(config) {
+    super();
+    debug('Hello, world!', config);
+    this.nextcolorTime = 0;
+  }
+
+  tick(time, delta) {
+    // If there's no moment to switch colors defined, pick such a moment,
+    // broadcast to clients.
+    if (!this.nextColorTime) {
+      this.nextColorTime = time + 1000;
+      network.emit('color', {
+        color : _.sample([
+          'red',
+          'green',
+          'blue',
+          'yellow',
+          'pink',
+          'violet',
+          'orange',
+          'cyan'
+        ]),
+        time : this.nextColorTime
+      });
+      debug('choose color', this.nextColorTime);
+      Promise.delay(1100).then((function() { this.nextColorTime = 0; }).bind(this));
+    }
+  }
+}
+
+register(HelloWorldServer, null);

--- a/server/modules/module_library.js
+++ b/server/modules/module_library.js
@@ -21,7 +21,7 @@ const assert = require('assert');
 
 class EmptyModuleDef extends ModuleDef {
   constructor() {
-    super('_empty');
+    super('_empty', '', {});
     // TODO(applmak): ^ this hacky.
     // However, b/c of the hack, this module will never become valid.
     this.whenLoadedPromise = Promise.resolve(this);
@@ -31,13 +31,13 @@ class EmptyModuleDef extends ModuleDef {
 class ModuleLibrary extends EventEmitter {
   constructor() {
     super();
-    
+
     this.reset();
   }
   register(def) {
     assert(!(def.name in this.modules), 'Def ' + def.name + ' already exists!');
     this.modules[def.name] = def;
-    // We can safely use 'on' rather than 'once' here, because neither the 
+    // We can safely use 'on' rather than 'once' here, because neither the
     // moduledefs nor this library are ever destroyed.
     def.on('reloaded', () => {
       this.emit('reloaded', def);

--- a/server/modules/module_loader.js
+++ b/server/modules/module_loader.js
@@ -67,14 +67,15 @@ class ModuleLoader {
         defaultConfig);
 
       if (cfg.extends) {
-        assert(cfg.extends in library.modules, 'Module ' + cfg.name + 
+        assert(cfg.extends in library.modules, 'Module ' + cfg.name +
           ' attempting to extend ' + cfg.extends + ' which was not found!');
         debug('Adding module ' + cfg.name + ' extending ' + cfg.extends);
         library.register(library.modules[cfg.extends].extend(
           cfg.name, cfg.title, cfg.author, cfg.config));
       } else {
-        debug('Adding module ' + cfg.name + ' from ' + path.join(cfg.root, cfg.path));
-        library.register(new ModuleDef(cfg.name, cfg.root, cfg.path, cfg.title,
+        const paths = {client: cfg.path || cfg.client_path, server: cfg.path || cfg.server_path};
+        debug('Adding module ' + cfg.name + ' from ' + path.join(cfg.root, paths.server));
+        library.register(new ModuleDef(cfg.name, cfg.root, paths, cfg.title,
               cfg.author, cfg.config));
       }
     });


### PR DESCRIPTION
This simplifies some of the upcoming es6 work due to differences in how
the browser and node import non-es6-compatible modules.

Also provided is an example of what such a module looks like. This
should get cleaner post es6-module support.