### PR TITLE
Remove remnants of layout geometry:

### DIFF
--- a/client/modules/module.js
+++ b/client/modules/module.js
@@ -126,10 +126,7 @@ export class ClientModule {
       network: openNetwork,
       titleCard: this.titleCard.getModuleAPI(),
       state: new StateManager(openNetwork),
-      globalWallGeometry: this.geo,
-      wallGeometry: new Polygon(this.geo.points.map(function(p) {
-        return {x: p.x - this.geo.extents.x, y: p.y - this.geo.extents.y};
-      }, this)),
+      wallGeometry: this.geo,
       peerNetwork,
       assert,
     }

--- a/demo_modules/.jshintrc
+++ b/demo_modules/.jshintrc
@@ -5,7 +5,6 @@
     "chrome": false,
     "debug": false,
     "game": false,
-    "globalWallGeometry": false,
     "Headers": false,
     "network": false,
     "peerNetwork": false,

--- a/demo_modules/wind/wind.js
+++ b/demo_modules/wind/wind.js
@@ -16,7 +16,6 @@ limitations under the License.
 const d3 = require('d3');
 const register = require('register');
 const ModuleInterface = require('lib/module_interface');
-const globalWallGeometry = require('globalWallGeometry');
 const wallGeometry = require('wallGeometry');
 const network = require('network');
 
@@ -85,13 +84,13 @@ class WindClient extends ModuleInterface.Client {
     this.overlaySurface = new CanvasSurface(container, wallGeometry);
     this.animationSurface = new CanvasSurface(container, wallGeometry);
 
-    this.scale = 2.5 * (globalWallGeometry.extents.w / 3);
+    this.scale = 2.5 * (wallGeometry.extents.w / 3);
 
     this.projection = d3.geoOrthographic()
       .scale(this.scale)
       .rotate([ROTATEX, ROTATEY])
-      .translate([globalWallGeometry.extents.w/2 - this.virtualRect.x,
-                  globalWallGeometry.extents.h/2 - this.virtualRect.y])
+      .translate([wallGeometry.extents.w/2 - this.virtualRect.x,
+                  wallGeometry.extents.h/2 - this.virtualRect.y])
       .clipAngle(90);
 
     // Bounds relative to the virtual rectangle.
@@ -143,14 +142,14 @@ class WindClient extends ModuleInterface.Client {
 
     function drawSphere(context, virtualRect) {
       const grad = context.createRadialGradient(
-        globalWallGeometry.extents.w/2 - virtualRect.x, globalWallGeometry.extents.h/2 - virtualRect.y, 0,
-        globalWallGeometry.extents.w/2 - virtualRect.x, globalWallGeometry.extents.h/2 - virtualRect.y, r);
+        wallGeometry.extents.w/2 - virtualRect.x, wallGeometry.extents.h/2 - virtualRect.y, 0,
+        wallGeometry.extents.w/2 - virtualRect.x, wallGeometry.extents.h/2 - virtualRect.y, r);
       grad.addColorStop(.69, "#303030");
       grad.addColorStop(.91, "#202020");
       grad.addColorStop(.96, "#000005");
       context.fillStyle = grad;
-      context.fillRect(0, 0, globalWallGeometry.extents.w,
-        globalWallGeometry.extents.h);
+      context.fillRect(0, 0, wallGeometry.extents.w,
+        wallGeometry.extents.h);
     }
 
     function drawGraticules(context) {

--- a/server/modules/module.js
+++ b/server/modules/module.js
@@ -13,13 +13,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {StateManager} from '../state/state_manager.js';
-import assert from '../../lib/assert.js';
 import * as game from '../game/game.js';
-import network from '../network/network.js';
-
 import Debug from 'debug';
+import assert from '../../lib/assert.js';
+import network from '../network/network.js';
+import {StateManager} from '../state/state_manager.js';
 import {error} from '../util/log.js';
+import {getGeo} from '../util/wall_geometry.js';
+
 const debug = Debug('wall:server_state_machine');
 const logError = error(debug);
 
@@ -28,15 +29,14 @@ export class RunningModule {
    * Constructs a running module.
    * NOTE that's it's fine to create one of these with no def, which will simply blank the screen.
    */
-  constructor(moduleDef, geo, deadline) {
+  constructor(moduleDef, deadline) {
     assert(moduleDef, 'Empty def passed to running module!');
     this.moduleDef = moduleDef;
-    this.geo = geo;
     this.deadline = deadline;
 
     if (this.moduleDef.valid) {
       // Only instantiate support objects for valid module defs.
-      const INSTANTIATION_ID = `${geo.extents.serialize()}-${deadline}`;
+      const INSTANTIATION_ID = `${getGeo().extents.serialize()}-${deadline}`;
       this.network = network.forModule(INSTANTIATION_ID);
       this.gameManager = game.forModule(INSTANTIATION_ID);
     } else {
@@ -51,7 +51,7 @@ export class RunningModule {
     if (this.network) {
       let openNetwork = this.network.open();
       this.stateManager = new StateManager(openNetwork);
-      this.instance = this.moduleDef.instantiate(this.geo, openNetwork, this.gameManager, this.stateManager, this.deadline);
+      this.instance = this.moduleDef.instantiate(openNetwork, this.gameManager, this.stateManager, this.deadline);
     }
   }
 

--- a/server/modules/server_state_machine.js
+++ b/server/modules/server_state_machine.js
@@ -100,7 +100,7 @@ class PrepareState extends State {
     // Don't begin preparing the module until we've loaded it.
     this.moduleDef_.whenLoadedPromise.then(() => {
       // The module we're trying to load.
-      this.module_ = new RunningModule(this.moduleDef_, wallGeometry.getGeo(), this.deadline_);
+      this.module_ = new RunningModule(this.moduleDef_, this.deadline_);
       this.module_.instantiate();
 
       // Tell the old server module that it will be hidden soon.


### PR DESCRIPTION
- rm custom geometry per moduledef. Instead, just use the normal
  wall geometry.
- rm old reference to moduledef.def. Since we now load code by import,
  we don't need any source to live in the framework code.
- rm global wall geometry. This was useful when layouts had a custom
  polygon, but these are long gone.