### PR TITLE
Improve title & author

### DIFF
--- a/client/modules/module.js
+++ b/client/modules/module.js
@@ -88,7 +88,7 @@ export class ClientModule {
       bits.module.name,
       bits.module.path,
       bits.module.config,
-      new TitleCard(bits.module),
+      new TitleCard(bits.module.credit),
       bits.time,
       new Polygon(bits.geo)
     );

--- a/client/style.css
+++ b/client/style.css
@@ -81,6 +81,7 @@ div[debug] {
     background-color: rgba(0, 0, 0, 0.4);
     font: 180px Podkova,sans-serif;
     z-index: 1000;
+    white-space: nowrap;
 }
 
 .beam {

--- a/demo_modules/balls/brick.json
+++ b/demo_modules/balls/brick.json
@@ -2,6 +2,8 @@
   "name": "balls",
   "client_path": "./balls_client.js",
   "server_path": "./balls_server.js",
-  "title": "Bouncing Balls",
-  "author": "Matt Handley"
+  "credit": {
+    "title": "Bouncing Balls",
+    "author": "Matt Handley"
+  }
 }

--- a/demo_modules/big_image_carousel/big_image_carousel_client.js
+++ b/demo_modules/big_image_carousel/big_image_carousel_client.js
@@ -54,6 +54,9 @@ export function load(wallGeometry, asset) {
       p5.strokeWeight(4);
       // Each instance will only ever draw images from one Y offset, but many X offsets.
 
+      if (!this.tiles || !this.tiles.length) {
+        return;
+      }
       this.sum_tile_width = 0;
       for (let x = 0; x < this.tiles.length; x++) {
         this.sum_tile_width += this.tiles[x].width;

--- a/demo_modules/chaos/brick.json
+++ b/demo_modules/chaos/brick.json
@@ -2,6 +2,8 @@
   "name": "chaos",
   "client_path": "./chaos_client.js",
   "server_path": "./chaos_server.js",
-  "title": "Chaos Theory",
-  "author": "Matt Cruikshank"
+  "credit": {
+    "title": "Chaos Theory",
+    "author": "Matt Cruikshank"
+  }
 }

--- a/demo_modules/chicago-brick-live/brick.json
+++ b/demo_modules/chicago-brick-live/brick.json
@@ -2,6 +2,8 @@
   "name": "chicago-brick-live",
   "client_path": "./chicago-brick-live-client.js",
   "server_path": "./chicago-brick-live-server.js",
-  "title": "Chicago Brick Live",
-  "author": "Ian Atkinson"
+  "credit": {
+    "title": "Chicago Brick Live",
+    "author": "Ian Atkinson"
+  }
 }

--- a/demo_modules/cosines/brick.json
+++ b/demo_modules/cosines/brick.json
@@ -1,6 +1,8 @@
 {
   "name": "cosines",
   "client_path": "./cosines.js",
-  "title": "Cosines",
-  "author": "Matt Cruikshank"
+  "credit": {
+    "title": "Cosines",
+    "author": "Matt Cruikshank"
+  }
 }

--- a/demo_modules/gears/brick.json
+++ b/demo_modules/gears/brick.json
@@ -2,6 +2,8 @@
   "name": "gears",
   "client_path": "./gears_client.js",
   "server_path": "./gears_server.js",
-  "title": "Gears",
-  "author": "Matt Handley"
+  "credit": {
+    "title": "Gears",
+    "author": "Matt Handley"
+  },
 }

--- a/demo_modules/merge_balls/brick.json
+++ b/demo_modules/merge_balls/brick.json
@@ -2,6 +2,8 @@
   "name": "merge-balls",
   "client_path": "./merge_balls_client.js",
   "server_path": "./merge_balls_server.js",
-  "title": "Hungry Hungry Circles",
-  "author": "Ian Atkinson"
+  "credit": {
+    "title": "Hungry Hungry Circles",
+    "author": "Ian Atkinson"
+  }
 }

--- a/demo_modules/operational_tests/brick.json
+++ b/demo_modules/operational_tests/brick.json
@@ -2,18 +2,18 @@
   {
     "name": "registration",
     "client_path": "./registration.js",
-    "title": "Registration Test",
-    "author": "Matt Handley"
   },
   {
     "name": "p5_test",
     "client_path": "./p5_test.js",
-    "title": "p5 surface test",
-    "author": "Jason Gessner"
   },
   {
     "name": "memory-debug",
-    "client_path": "./memory_debug.js"
+    "client_path": "./memory_debug.js",
+    "credit": {
+      "title": "Super Long Title That Will Totally Cause Wrapping",
+      "author": "Author, who likes to have<br>his name on two lines."
+    }
   },
   {
     "name": "genlock-test",
@@ -22,7 +22,5 @@
   {
     "name": "threejs",
     "client_path": "./threejs_test.js",
-    "title": "threejs test",
-    "author": "Matt Handley"
   }
 ]

--- a/demo_modules/p5_game_of_life/brick.json
+++ b/demo_modules/p5_game_of_life/brick.json
@@ -2,6 +2,8 @@
   "name": "life",
   "client_path": "./p5_game_of_life_client.js",
   "server_path": "./p5_game_of_life_server.js",
-  "title": "The Game of Life",
-  "author": "Jason Gessner"
+  "credit": {
+    "title": "The Game of Life",
+    "author": "Jason Gessner"
+  }
 }

--- a/demo_modules/slideshow/brick.json
+++ b/demo_modules/slideshow/brick.json
@@ -3,7 +3,9 @@
     "name": "slideshow",
     "client_path": "./slideshow_client.js",
     "server_path": "./slideshow_server.js",
-    "title": "Slideshow"
+    "credit": {
+      "title": "Slideshow"
+    }
   },
   {
     "name": "cta",

--- a/demo_modules/slither/brick.json
+++ b/demo_modules/slither/brick.json
@@ -2,8 +2,10 @@
   "name": "slither",
   "client_path": "./slither_client.js",
   "server_path": "./slither_server.js",
-  "title": "Slither",
-  "author": "Matt Handley",
+  "credit": {
+    "title": "Slither",
+    "author": "Matt Handley",
+  },
   "config": {
     "numSnakes": 100
   }

--- a/demo_modules/solid/brick.json
+++ b/demo_modules/solid/brick.json
@@ -1,8 +1,10 @@
 {
   "name": "solid",
   "client_path": "./solid.js",
-  "title": "Solid Color",
-  "author": "Matt Handley",
+  "credit": {
+    "title": "Solid Color",
+    "author": "Matt Handley",
+  },
   "config": {
     "color": "yellow"
   }

--- a/server/modules/module_def.js
+++ b/server/modules/module_def.js
@@ -62,13 +62,12 @@ function extractFromImport(name, moduleRoot, modulePath, network, game, state) {
  * instantiate a module, including code location and config parameters.
  */
 export class ModuleDef extends EventEmitter {
-  constructor(name, moduleRoot, pathsOrBaseModule, title, author, config) {
+  constructor(name, moduleRoot, pathsOrBaseModule, config, credit) {
     super();
     this.name = name;
     this.root = moduleRoot;
-    this.config = config || {};
-    this.title = title;
-    this.author = author;
+    this.config = config;
+    this.credit = credit;
 
     // The path to the client main file of the module.
     this.clientPath = '';
@@ -112,19 +111,17 @@ export class ModuleDef extends EventEmitter {
       clientPath: this.clientPath,
       serverPath: this.serverPath,
       config: util.inspect(this.config),
-      title: this.title,
-      author: this.author
     };
   }
   // Returns a new module def that extends this def with new configuration.
-  extend(name, title, author, config) {
+  extend(name, config, credit) {
     return new ModuleDef(
       name,
       this.root,
       {base: this},
-      title === undefined ? '' : (title || this.title),
-      author === undefined ? '' : (author || this.author),
-      config);
+      config,
+      credit,
+    );
   }
 
   // Loads a module from disk asynchronously, assigning def when complete.
@@ -165,8 +162,7 @@ export class ModuleDef extends EventEmitter {
       name: this.name,
       path: path.join('/module/', this.name, this.clientPath),
       config: this.config,
-      title: this.title,
-      author: this.author,
+      credit: this.credit,
     };
   }
 }

--- a/server/modules/module_loader.js
+++ b/server/modules/module_loader.js
@@ -70,12 +70,12 @@ export class ModuleLoader {
           ' attempting to extend ' + cfg.extends + ' which was not found!');
         debug('Adding module ' + cfg.name + ' extending ' + cfg.extends);
         library.register(library.modules[cfg.extends].extend(
-          cfg.name, cfg.title, cfg.author, cfg.config));
+            cfg.name, cfg.config || {}, cfg.credit || {}));
       } else {
         const paths = {client: cfg.path || cfg.client_path, server: cfg.path || cfg.server_path};
         debug('Adding module ' + cfg.name);
-        library.register(new ModuleDef(cfg.name, cfg.root, paths, cfg.title,
-              cfg.author, cfg.config));
+        library.register(new ModuleDef(
+              cfg.name, cfg.root, paths, cfg.config || {}, cfg.credit || {}));
       }
     });
 


### PR DESCRIPTION
- Move title and author out of 'config' object and onto special 'credit' key, which makes it easier to support a more complex set of titles.
- Fix title overflowing by shrinking title text to fit.
- Fix random bug in big_image_carousel that I uncovered while I was here that caused the module to infinite loop.