### PR TITLE
Multiplex per-module network on a single connection

### DIFF
--- a/client/modules/module_test.js
+++ b/client/modules/module_test.js
@@ -25,34 +25,31 @@ describe('client module', () => {
     expect(injectedState).not.to.be.null;
   });
   describe('cleanup', () => {
-    let networkClose;
+    let m;
 
-    function makeLoad(body) {
-      return function(network) {
-        networkClose = sinon.spy(network, 'close');
-        return body();
-      }
-    }
+    beforeEach(() => {
+      m = null;
+    });
 
     describe('cleans up dependencies', () => {
       afterEach(() => {
-        expect(networkClose).to.have.been.called;
+        expect(m.network).to.be.null;
       });
       it('when load throws', async () => {
-        const m = fakes.makeClientModule(makeLoad(fakes.THROWS_ON_LOAD));
+        m = fakes.makeClientModule(fakes.THROWS_ON_LOAD);
         await willReject(() => m.instantiate());
       });
       it('if module constructor throws', async () => {
-        const m = fakes.makeClientModule(makeLoad(fakes.THROWS_ON_CONSTRUCTION));
+        m = fakes.makeClientModule(fakes.THROWS_ON_CONSTRUCTION);
         await willReject(() => m.instantiate());
       });
       it('if willBeShownSoon throws', async () => {
-        const m = fakes.makeClientModule(makeLoad(fakes.THROWS_ON_WILL_BE_SHOWN_SOON));
+        m = fakes.makeClientModule(fakes.THROWS_ON_WILL_BE_SHOWN_SOON);
         await m.instantiate();
         await willReject(() => m.willBeShownSoon());
       });
       it('when beginTransitionIn throws', async () => {
-        const m = fakes.makeClientModule(makeLoad(fakes.THROWS_ON_BEGIN_FADE_IN));
+        m = fakes.makeClientModule(fakes.THROWS_ON_BEGIN_FADE_IN);
         await m.instantiate();
         await willReject(() => m.beginTransitionIn());
       });
@@ -60,20 +57,20 @@ describe('client module', () => {
 
     describe('does not clean up dependencies', () => {
       afterEach(() => {
-        expect(networkClose).not.to.have.been.called;
+        expect(m.network).not.to.be.null;
       });
       it('when beginTransitionOut throws', async () => {
-        const m = fakes.makeClientModule(makeLoad(fakes.THROWS_ON_BEGIN_FADE_OUT));
+        m = fakes.makeClientModule(fakes.THROWS_ON_BEGIN_FADE_OUT);
         await m.instantiate();
         await willReject(() => m.beginTransitionOut());
       });
       it('when finishTransitionIn throws', async () => {
-        const m = fakes.makeClientModule(makeLoad(fakes.THROWS_ON_FINISH_FADE_IN));
+        m = fakes.makeClientModule(fakes.THROWS_ON_FINISH_FADE_IN);
         await m.instantiate();
         await willReject(() => m.finishTransitionIn());
       });
       it('when finishTransitionOut throws', async () => {
-        const m = fakes.makeClientModule(makeLoad(fakes.THROWS_ON_FINISH_FADE_OUT));
+        m = fakes.makeClientModule(fakes.THROWS_ON_FINISH_FADE_OUT);
         await m.instantiate();
         await willReject(() => m.finishTransitionOut());
       });

--- a/demo_modules/slideshow/fullscreen_display_server.js
+++ b/demo_modules/slideshow/fullscreen_display_server.js
@@ -26,7 +26,7 @@ function pick(arr) {
   return null;
 }
 
-export default function({debug, wallGeometry, network}) {
+export default function({debug, network}) {
   // FULLSCREEN DISPLAY STRATEGY
   // This display strategy shows a single element per screen, updating at a rate
   // specified in the config. We wait for the corresponding element to load
@@ -62,11 +62,9 @@ export default function({debug, wallGeometry, network}) {
       });
 
       // Tell the clients about content when it arrives.
-      network.on('connection', (socket) => {
-        socket.on('display:init', () => {
-          contentHasArrived.then(() => {
-            this.chooseSomeContent(socket);
-          });
+      network.on('display:init', (data, socket) => {
+        contentHasArrived.then(() => {
+          this.chooseSomeContent(socket);
         });
       });
     }
@@ -107,7 +105,7 @@ export default function({debug, wallGeometry, network}) {
         // Otherwise, tell a specific client to show a specific bit of content.
         if (time - this.lastUpdate >= this.config.period) {
           // Pick a random client.
-          let client = pick(network.getClientsInRect(wallGeometry.extents));
+          let client = pick(Object.values(network.clients));
           if (client) {
             this.chooseSomeContent(client.socket);
           }

--- a/demo_modules/slideshow/slideshow_client.js
+++ b/demo_modules/slideshow/slideshow_client.js
@@ -65,6 +65,7 @@ export function load(wallGeometry, debug, network, assert, asset) {
         debug('Waiting for network init...');
         network.emit('req_init');
         network.once('init', config => {
+          debug('Init received.');
           this.loadStrategy = parseClientLoadStrategy(config.load);
           this.displayStrategy = parseClientDisplayStrategy(config.display);
           this.loadStrategy.init(this.surface, deadline);

--- a/lib/module_player.js
+++ b/lib/module_player.js
@@ -101,8 +101,8 @@ export function configure({makeEmptyModule, monitor, debug, time, logError}) {
         debug(`Instantiating module ${module.name}.`);
         await Promise.race([module.instantiate(), delayThenReject(5000)]);
       } catch (e) {
-        // If this throws, it's because of the delayed rejection.
-        logError(new Error(`Module ${module.name} timed out in instantiation.`), {
+        const err = e || new Error(`Module ${module.name} timed out in preparation.`);
+        logError(err, {
           module: module.name,
           timestamp: time.now(),
           timestampSinceModuleStart: time.now() - module.deadline,
@@ -134,9 +134,8 @@ export function configure({makeEmptyModule, monitor, debug, time, logError}) {
       try {
         await Promise.race([module.willBeShownSoon(), delayThenReject(5000)]);
       } catch (e) {
-        // If this throws, it's because the delayed rejection.
-        debug(e);
-        logError(new Error(`Module ${module.name} timed out in preparation.`), {
+        const err = e || new Error(`Module ${module.name} timed out in preparation.`);
+        logError(err, {
           module: module.name,
           timestamp: time.now(),
           timestampSinceModuleStart: time.now() - module.deadline,

--- a/lib/socket_wrapper.js
+++ b/lib/socket_wrapper.js
@@ -1,0 +1,138 @@
+/**
+ * Wrap a socket with handlers for sending and receiving per-module messages.
+ */
+
+import Debug from './lame_es6/debug.js';
+const debug = Debug('wall:lib:socket_wrapper');
+
+// A map of module-id -> [message]
+const earlyMessagesPerId = {};
+
+// A map of module-id -> {messageName: (data, socket) -> void}
+const messageHandlersPerId = {};
+
+// Make a variable that lazily initializes. The resulting value must be truthy.
+function lazyInit(init) {
+  let i;
+  return () => (i || (i = init()));
+}
+
+/**
+ * Remove every element of arr for which fn returns true, and returns an array
+ * of those removed elements.
+ */
+function removeIf(arr, fn) {
+  const indicesToRemove = [];
+  const ret = arr.filter((m, i) => {
+    if (fn(m)) {
+      indicesToRemove.push(i);
+      return true;
+    }
+    return false;
+  });
+  indicesToRemove.reverse();
+  indicesToRemove.forEach(i => arr.splice(i, 1));
+  return ret;
+}
+
+/**
+ * Deliver a message to handlers.
+ * Messages are sent via the wrapper and so are always of the same form:
+ * {
+ *   id: The unique module identifier.
+ *   name: The original name of the message the module sent.
+ *   payload: The payload of the original message.
+ * }
+ * The socket is the unwrapped socket that received this message.
+ */
+function deliverMessage(data, socket) {
+  const {id, name, payload} = data;
+  const wrappedSocket = lazyInit(() => wrapMessageSocket(id, socket));
+  if (id in messageHandlersPerId) {
+    const messageHandlers = messageHandlersPerId[id];
+    if (name in messageHandlers) {
+      // We have a handler registered for this message. Invoke it. Note that
+      // these handlers are expected to run in module-land, we send along a
+      // wrapped socket.
+      //debug(`received ${name} ${id}`);
+      messageHandlers[name](payload, wrappedSocket());
+    } else {
+      // We don't have a handler for this message. We could drop it, but it's
+      // quite possible that the handler just hasn't yet been registered.
+      // Instead, we'll retain it for when that handler gets registered. If it
+      // never shows up, that's a big waste of memory, but it will eventually
+      // get cleaned up when the module is finished.
+      //debug(`cached ${name} ${id}`);
+      earlyMessagesPerId[id].push({data, socket});
+    }
+  } else {
+    // We received a message for a module we don't know about.
+    // If we hang onto this message, and we never learn about this module,
+    // we'll never clean it up, so we are forced to drop it.
+    debug(`Received a message for unknown module id: ${id}`);
+  }
+}
+
+/**
+ * Installs the message handler to a socket.
+ * This should be invoked on the "framework-level" sockets; those which don't
+ * close, but stay open between the client & server for the whole operation of
+ * the binary. As a result, it doesn't need to get cleaned up.
+ */
+export function installMessageHandler(socket) {
+  socket.on('module-message', d => deliverMessage(d, socket));
+}
+
+/**
+ * Creates a facade over a socket that emulates the socket.io API.
+ * This is the most complex part of the wrapper.
+ */
+export function wrapMessageSocket(id, socket, additionalMethods = {}) {
+  // Initialize our per-module stores.
+  messageHandlersPerId[id] = messageHandlersPerId[id] || {};
+  earlyMessagesPerId[id] = earlyMessagesPerId[id] || [];
+
+  // Returns an API suitable to pass into module code. It emulates the socket.io
+  // API but wraps it to ensure that modules cannot talk to other modules (or
+  // even other instances of the same module).
+  return {
+    // Emits a message via the wrapped socket.
+    emit(messageName, payload) {
+      //debug(`sent ${messageName} ${socket.id}`);
+      socket.emit('module-message', {
+        id,
+        name: messageName,
+        payload
+      });
+    },
+    // Adds a listener for the named message, which will invoke the cb when
+    // it arrives on the wrapped socket. If once is true, the cb will be
+    // unregistered after it is invoked.
+    on(messageName, cb, once = false) {
+      const actualCb = !once ? cb : (...args) => {
+        // Invoke the callback...
+        cb(...args);
+        // And then pretend that I've never registered in the first place.
+        delete messageHandlersPerId[id][messageName];
+      };
+      // Add the handler to our list of handlers for this module.
+      messageHandlersPerId[id][messageName] = actualCb;
+      // If there are messages that arrived on this module already, invoke them.
+      const earlyMessages = earlyMessagesPerId[id];
+      if (earlyMessages) {
+        const messagesToDeliver = removeIf(earlyMessages, m => m.data.name == messageName);
+        messagesToDeliver.forEach(({data, socket}) => deliverMessage(data, socket));
+      }
+    },
+    once(messageName, cb) {
+      this.on(messageName, cb, true);
+    },
+    // Add arbitrary additional methods/properties to the API.
+    ...additionalMethods,
+  };
+}
+
+export function cleanupMessageHandlers(id) {
+  delete messageHandlersPerId[id];
+  delete earlyMessagesPerId[id];
+}

--- a/lib/socket_wrapper_test.js
+++ b/lib/socket_wrapper_test.js
@@ -1,0 +1,64 @@
+import {installMessageHandler, wrapMessageSocket, cleanupMessageHandlers} from './socket_wrapper.js';
+
+const expect = chai.expect;
+
+function makeSockets() {
+  const registry = {};
+  const receiver = {
+    on(messageName, cb) {
+      registry[messageName] = cb;
+    }
+  };
+  const sender = {
+    emit(messageName, payload) {
+      registry[messageName](payload);
+    }
+  };
+  return {receiver, sender};
+}
+
+describe('socket wrapper', () => {
+  let sender, receiver;
+  let wrappedSender, wrappedReceiver;
+  beforeEach(() => {
+    ({sender, receiver} = makeSockets());
+    installMessageHandler(receiver);
+    wrappedSender = wrapMessageSocket('id1', sender);
+    wrappedReceiver = wrapMessageSocket('id1', receiver);
+  });
+  it('allows sending messages', () => {
+    const receiverSpy = sinon.spy();
+    const wrappedReceiverSpy = sinon.spy();
+    receiver.on('some message', receiverSpy);
+    wrappedReceiver.on('some message', wrappedReceiverSpy);
+    wrappedSender.emit('some message', {});
+    expect(receiverSpy).not.to.have.been.called;
+    expect(wrappedReceiverSpy).to.have.been.called;
+  });
+  it('prevents sending messages from another wrapper', () => {
+    const wrappedSender2 = wrapMessageSocket('id2', sender);
+    const wrappedReceiver2 = wrapMessageSocket('id2', receiver);
+    const wrappedReceiverSpy = sinon.spy();
+    const wrappedReceiver2Spy = sinon.spy();
+    wrappedReceiver.on('some message', wrappedReceiverSpy);
+    wrappedReceiver2.on('some message', wrappedReceiver2Spy);
+    wrappedSender.emit('some message', {});
+    expect(wrappedReceiverSpy).to.have.been.called;
+    expect(wrappedReceiver2Spy).not.to.have.been.called;
+
+    wrappedReceiverSpy.resetHistory();
+    wrappedSender2.emit('some message', {});
+    expect(wrappedReceiverSpy).not.to.have.been.called;
+    expect(wrappedReceiver2Spy).to.have.been.called;
+  });
+  it('cleanup prevents further messages', () => {
+    cleanupMessageHandlers('id1');
+    expect(() => wrappedSender.emit('some message', {})).to.throw;
+  });
+  it('supports late-registering handlers', () => {
+    wrappedSender.emit('some message', {});
+    const wrappedReceiverSpy = sinon.spy();
+    wrappedReceiver.on('some message', wrappedReceiverSpy);
+    expect(wrappedReceiverSpy).to.have.been.called;
+  });
+});


### PR DESCRIPTION
This completely changes the way that per-module networking works.
Before, we relied on socket.io namespaces to ensure that no module could
accidentally communicate with another module that was running at the
same time. This worked, but had three major drawbacks:

1. Relied on internal, undocumented socket.io APIs to ensure proper
   cleanup of namespace sockets.
2. Messages sent before receiver was ready were dropped, which required
   modules to invent complicated mechanisms to ensure both server &
   client were ready before communicating.
3. Initial handshake on namespace caused a noticeable CPU spike on the
   client which dropped some frames.

This change addresses each of those concerns:
1. One socket is opened per server and client, avoiding the need for
   cleanup.
2. Messages are always queued up and processed when the other party
   inits and begins registering handlers.
3. No additional connections are formed, removing the CPU spike.

This changes the API for modules, though, as there is no more
'connection' or 'reconnect' messages (as we maintain a persistent)
connection. Module authors are advised to instead have clients send a
message to the server when ready to receive any critical missives, and
the new infrastructure will ensure proper behavior.