### PR TITLE
Fix network.clients API.

### DIFF
--- a/demo_modules/slideshow/fullscreen_display_server.js
+++ b/demo_modules/slideshow/fullscreen_display_server.js
@@ -105,7 +105,7 @@ export default function({debug, network}) {
         // Otherwise, tell a specific client to show a specific bit of content.
         if (time - this.lastUpdate >= this.config.period) {
           // Pick a random client.
-          let client = pick(Object.values(network.clients));
+          let client = pick(Object.values(network.clients()));
           if (client) {
             this.chooseSomeContent(client.socket);
           }

--- a/server/network/network.js
+++ b/server/network/network.js
@@ -154,7 +154,7 @@ export function forModule(id) {
         // TODO(applmak): If a module chooses to listen on a per-client wrapped
         // socket like this, it will remove other any such listener. Fix this
         // in order to match socket.io behavior, if possible.
-        get clients() {
+        clients() {
           return Object.keys(clients).reduce((agg, clientId) => {
             agg[clientId] = {
               ...clients[clientId],


### PR DESCRIPTION
- As a property, it was getting *copied* into the wrapped socket, which
  freezes the set of clients to the ones that were originally set.
- Making it a function copies the definition of the function and
  hence makes the list of clients dynamic and current.