### PR TITLE
Disable perMessageDeflate.

### DIFF
--- a/demo_modules/slideshow/load_from_drive_server.js
+++ b/demo_modules/slideshow/load_from_drive_server.js
@@ -140,16 +140,20 @@ export default function({debug}) {
 
       // Check if we already have it cached.
       if (cache.has(key)) {
+        debug(`Clipping region ${clippingRect.serialize()} for ${fileId} was cached`);
         return cache.get(key);
       }
       // Check if we are already creating a cropped form of this.
       if (this.inflightContent.has(key)) {
+        debug(`Clipping region ${clippingRect.serialize()} for ${fileId} is being computed now`);
         return await this.inflightContent.get(key);
       }
 
+      debug(`Clipping region ${clippingRect.serialize()} for ${fileId}`);
       const promise = this.clipImage(content, clippingRect, cache);
       this.inflightContent.set(key, promise);
       const clippedImage = await promise;
+      debug(`Clipping region ${clippingRect.serialize()} for ${fileId} complete`);
 
       // Cache the cropped image into the cache so we don't have to look this up again.
       cache.set(key, clippedImage);

--- a/server/network/network.js
+++ b/server/network/network.js
@@ -62,7 +62,9 @@ export const emitter = new EventEmitter;
  * Initializes the networking layer, given an httpserver instance.
  */
 export function init(server) {
-  io = socketio(server);
+  // Disable per-message compression, because it causes big issues on linux.
+  // https://github.com/websockets/ws#websocket-compression
+  io = socketio(server, {perMessageDeflate: false});
 
   io.on('connection', socket => {
     // When the client boots, it sends a start message that includes the rect


### PR DESCRIPTION
According to https://github.com/websockets/ws#websocket-compression,
node has some issues when this is enabled. Turns out, socket.io enables
it by default. For even tiny binary messages (10KB) with a large number
of clients, I was seeing 4s delays in sending and receiving.