### PR TITLE
Change module registration to happen more dynamically.

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>hi</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="/client/style.css" />
     <script src="/client/client.js" type="module"></script>
   </head>
   <body>

--- a/client/surface/threejs_surface.js
+++ b/client/surface/threejs_surface.js
@@ -14,7 +14,7 @@ limitations under the License.
 ==============================================================================*/
 
 import {Surface} from '/client/surface/surface.js';
-import * as Three from '/sys/three-full/builds/Three.es.js';
+import * as Three from '/node_modules/three-full/builds/Three.es.js';
 
 export class ThreeJsSurface extends Surface {
   constructor(container, wallGeometry, properties) {

--- a/client/util/time.js
+++ b/client/util/time.js
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import ClockSkew from '/sys/clock-skew/lib/clock_skew.js';
+import ClockSkew from '/node_modules/clock-skew/lib/clock_skew.js';
 
 const clockSkew = ClockSkew({});
 

--- a/demo_modules/operational_tests/threejs_test.js
+++ b/demo_modules/operational_tests/threejs_test.js
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import * as Three from '/sys/three-full/builds/Three.es.js';
+import * as Three from '/node_modules/three-full/builds/Three.es.js';
 import {ThreeJsSurface} from '/client/surface/threejs_surface.js';
 
 export function load(wallGeometry) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,6 @@ module.exports = function(config) {
       '/lib/': '/base/lib/',
       '/client/': '/base/client/',
       '/server/': '/base/server/',
-      '/sys/': '/base/node_modules/',
     },
 
     // list of files / patterns to exclude

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "body-parser": "^1.18.3",
     "chalk": "^2.4.2",
     "clock-skew": "^0.3.0",
     "command-line-args": "^5.0.0",

--- a/server/modules/module.js
+++ b/server/modules/module.js
@@ -24,6 +24,7 @@ import * as stateManager from '../state/state_manager.js';
 import {delay} from '../../lib/promise.js';
 import {getGeo} from '../util/wall_geometry.js';
 import {clients} from '../network/network.js';
+import {registerRoute, unregisterRoute} from './serving.js';
 
 export function tellClientToPlay(client, name, deadline) {
   client.socket.emit('loadModule', {
@@ -69,6 +70,7 @@ export class RunningModule {
       tellClientToPlay(clients[id], this.name, this.deadline);
     }
     if (this.network) {
+      registerRoute(this.name, this.moduleDef.root);
       let openNetwork = this.network.open();
       let openState = this.stateManager.open();
       this.instance = this.moduleDef.instantiate(openNetwork, this.gameManager, openState, this.deadline);
@@ -107,6 +109,8 @@ export class RunningModule {
       // This also cleans up stateManager.
       this.network.close();
       this.network = null;
+
+      unregisterRoute(this.name);
     }
   }
 

--- a/server/modules/serving.js
+++ b/server/modules/serving.js
@@ -13,16 +13,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-import {easyLog} from '../lib/log.js';
+import {easyLog} from '../../lib/log.js';
 import express from 'express';
 import fs from 'fs';
 import glob from 'glob';
-import library from './modules/module_library.js';
+import library from './module_library.js';
 import path from 'path';
 
 const fsp = fs.promises;
 
-const log = easyLog('wall:webapp');
+const log = easyLog('wall:serving');
 
 function serveFile(path) {
   return async (req, res) => {

--- a/server/server.js
+++ b/server/server.js
@@ -20,7 +20,7 @@ import * as game from './game/game.js';
 import * as monitor from './monitoring/monitor.js';
 import * as network from './network/network.js';
 import * as wallGeometry from './util/wall_geometry.js';
-import * as webapp from './webapp.js';
+import * as moduleServing from './modules/serving.js';
 import library from './modules/module_library.js';
 import commandLineArgs from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
@@ -122,7 +122,7 @@ if (playlist.length === 0) {
   throw new Error('Nothing to play!');
 }
 
-var app = webapp.create(flags);
+const app = moduleServing.create(flags);
 
 const modulePlayer = new ServerModulePlayer();
 const driver = new PlaylistDriver(modulePlayer);

--- a/server/webapp.js
+++ b/server/webapp.js
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 
 import {easyLog} from '../lib/log.js';
-import bodyParser from 'body-parser';
 import express from 'express';
 import fs from 'fs';
 import glob from 'glob';
@@ -111,11 +110,6 @@ export function create(flags) {
   app.use(brickRouter);
   app.use(assetRouter);
   app.use(moduleRouter);
-
-  // Needed by control.js for POST requests.
-  // TODO(applmak): Install this only on the needed router.
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({extended: false}));
 
   app.get('/', serveFile(path.join(brickPath, 'client/index.html')));
 


### PR DESCRIPTION
This is in preparation for splitting the server into a playlist part and a server part. Now, we don't need to do a whole separate glob in order to get at the module directories; rather, we just rely on the module definitions (which contain a root) to figure out the directories to serve..