### PR TITLE
Fix global content refreshes

### DIFF
--- a/demo_modules/slideshow/brick.json
+++ b/demo_modules/slideshow/brick.json
@@ -45,6 +45,27 @@
     "testonly": true
   },
   {
+    "name": "slideshow_local_video_presplit_test",
+    "extends": "slideshow",
+    "config": {
+      "load": {
+        "local": {
+          "directories": ["video/cobra"],
+          "video": {
+            "sync": true,
+            "syncDebug": true
+          }
+        }
+      },
+      "display": {
+        "fullscreen": {
+          "presplit": true
+        }
+      }
+    },
+    "testonly": true
+  },
+  {
     "name": "slideshow_local_period_test",
     "extends": "slideshow",
     "config": {


### PR DESCRIPTION
- Sometimes, you want global content to refresh when it finishes.
- This was handled all wrongly before
- Now, we are smart about how we update this global content when it finishes on a client.
- Also, add a test module that references the cobra videos.