### PR TITLE
Change behavior of module prep timeouts

### DIFF
--- a/lib/module_player.ts
+++ b/lib/module_player.ts
@@ -183,8 +183,14 @@ export class ModulePlayer {
         timestamp: time.now(),
         timestampSinceModuleStart: time.now() - module.deadline,
       });
-      module.dispose();
-      return;
+      if (err.message === "Timeout") {
+        // This was just a timeout. It could be that this one screen was slow. Don't stop
+        // the whole module from continuing. We won't wait for willBeShownSoon to finish
+        // before trying to tick/draw the module, though!
+      } else {
+        module.dispose();
+        return;
+      }
     }
     // While we were getting all of that together, which might have taken a bit
     // of time, we should check to make sure that we are still trying to be


### PR DESCRIPTION
- Before, we disposed the module.
- However, this can make _some_ screens dispose and others not, which looks weird.
- Instead, forge ahead.