### PR TITLE
Add template module + make inject work with comments.

### DIFF
--- a/demo_modules/_template/brick.json
+++ b/demo_modules/_template/brick.json
@@ -1,5 +1,6 @@
 {
     "name": "template",
+    "testonly": true,
     "client_path": "./template_client.ts",
     "server_path": "./template_server.ts"
   }

--- a/demo_modules/_template/brick.json
+++ b/demo_modules/_template/brick.json
@@ -1,0 +1,6 @@
+{
+    "name": "template",
+    "client_path": "./template_client.ts",
+    "server_path": "./template_server.ts"
+  }
+  

--- a/demo_modules/_template/template_client.ts
+++ b/demo_modules/_template/template_client.ts
@@ -1,20 +1,19 @@
+// deno-lint-ignore-file no-unused-vars
+
 import { Client } from "../../client/modules/module_interface.ts";
 import { ModuleWS } from "../../lib/websocket.ts";
-import { Logger } from "../../lib/log.ts";
 import { Polygon } from "../../lib/math/polygon2d.ts";
 import { CanvasSurface } from "../../client/surface/canvas_surface.ts";
 import { ModulePeer } from "../../client/network/peer.ts";
 import { ModuleState } from "../../client/network/state_manager.ts";
 
 export function load(
-  // Default logging lib, with multiple levels.
-  _debug: Logger,
   // Websocket connected to the client used to send messages back and forth.
-  _network: ModuleWS,
+  network: ModuleWS,
   // Helper to get information about other clients.
-  _peerNetwork: ModulePeer,
+  peerNetwork: ModulePeer,
   // Shared state with module's server.
-  _state: ModuleState,
+  state: ModuleState,
   // Polygon representing the outer shape of the entire wall area.
   wallGeometry: Polygon,
 ) {
@@ -32,13 +31,13 @@ export function load(
     }
 
     // Notification that your module has started to fade in.
-    beginFadeIn(_time: number) {}
+    beginFadeIn(time: number) {}
 
     // Notification that your module has finished fading in.
     finishFadeIn() {}
 
     // Notification that your module should now draw.
-    draw(_time: number, _delta: number) {
+    draw(time: number, delta: number) {
       // Erase previous frame.
       this.ctx.clearRect(
         0, // start x

--- a/demo_modules/_template/template_client.ts
+++ b/demo_modules/_template/template_client.ts
@@ -1,0 +1,76 @@
+import { Client } from "../../client/modules/module_interface.ts";
+import { ModuleWS } from "../../lib/websocket.ts";
+import { Logger } from "../../lib/log.ts";
+import { Polygon } from "../../lib/math/polygon2d.ts";
+import { CanvasSurface } from "../../client/surface/canvas_surface.ts";
+import { ModulePeer } from "../../client/network/peer.ts";
+import { ModuleState } from "../../client/network/state_manager.ts";
+
+export function load(
+  // Default logging lib, with multiple levels.
+  _debug: Logger,
+  // Websocket connected to the client used to send messages back and forth.
+  _network: ModuleWS,
+  // Helper to get information about other clients.
+  _peerNetwork: ModulePeer,
+  // Shared state with module's server.
+  _state: ModuleState,
+  // Polygon representing the outer shape of the entire wall area.
+  wallGeometry: Polygon,
+) {
+  class TemplateClient extends Client {
+    surface: CanvasSurface | undefined = undefined;
+    ctx!: CanvasRenderingContext2D;
+
+    // Notification that your module has been selected next in the queue.
+    willBeShownSoon(
+      container: HTMLElement,
+      _deadline: number,
+    ): Promise<void> | void {
+      this.surface = new CanvasSurface(container, wallGeometry);
+      this.ctx = this.surface.context;
+    }
+
+    // Notification that your module has started to fade in.
+    beginFadeIn(_time: number) {}
+
+    // Notification that your module has finished fading in.
+    finishFadeIn() {}
+
+    // Notification that your module should now draw.
+    draw(_time: number, _delta: number) {
+      // Erase previous frame.
+      this.ctx.clearRect(
+        0, // start x
+        0, // start y
+        this.surface!.virtualRect.w, // width
+        this.surface!.virtualRect.h, // height
+      );
+
+      // Draw circle.
+      this.ctx.beginPath();
+      this.ctx.arc(
+        this.surface!.virtualRect.w / 2, // center x
+        this.surface!.virtualRect.h / 2, // center y
+        this.surface!.virtualRect.h / 3, // radius
+        0, // start angle
+        2 * Math.PI, // end angle
+        false, // counterClockwise
+      );
+      this.ctx.fillStyle = "red";
+      this.ctx.fill();
+    }
+
+    // Notification that your module has started to fade out.
+    beginFadeOut() {}
+
+    // Notification that your module has finished fading out.
+    finishFadeOut() {
+      if (this.surface) {
+        this.surface.destroy();
+      }
+    }
+  }
+
+  return { client: TemplateClient };
+}

--- a/demo_modules/_template/template_server.ts
+++ b/demo_modules/_template/template_server.ts
@@ -1,28 +1,24 @@
+// deno-lint-ignore-file no-unused-vars
+
 import { Server } from "../../server/modules/module_interface.ts";
-import { Logger } from "../../lib/log.ts";
 import { ModuleState } from "../../server/network/state_manager.ts";
 import { Polygon } from "../../lib/math/polygon2d.ts";
-import { assert as libAssert } from "../../lib/assert.ts";
 import { ModuleWSS } from "../../server/network/websocket.ts";
 
 export function load(
-  // Generic assertion util.
-  _assert: typeof libAssert,
-  // Default logging lib, with multiple levels.
-  _debug: Logger,
   // Websocket connected to the client used to send messages back and forth.
-  _network: ModuleWSS,
+  network: ModuleWSS,
   // Shared state with module's client.
-  _state: ModuleState,
+  state: ModuleState,
   // Polygon representing the outer shape of the entire wall area.
-  _wallGeometry: Polygon,
+  wallGeometry: Polygon,
 ) {
   class TemplateServer extends Server {
     // Notification that your module has been selected next in the queue.
-    willBeShownSoon(_deadline: number): Promise<void> | void {}
+    willBeShownSoon(deadline: number): Promise<void> | void {}
 
     // Notification that your module should execute a tick of work.
-    tick(_time: number, _delta: number) {}
+    tick(time: number, delta: number) {}
 
     // Notification that your module has been removed from the clients.
     dispose() {}

--- a/demo_modules/_template/template_server.ts
+++ b/demo_modules/_template/template_server.ts
@@ -1,0 +1,32 @@
+import { Server } from "../../server/modules/module_interface.ts";
+import { Logger } from "../../lib/log.ts";
+import { ModuleState } from "../../server/network/state_manager.ts";
+import { Polygon } from "../../lib/math/polygon2d.ts";
+import { assert as libAssert } from "../../lib/assert.ts";
+import { ModuleWSS } from "../../server/network/websocket.ts";
+
+export function load(
+  // Generic assertion util.
+  _assert: typeof libAssert,
+  // Default logging lib, with multiple levels.
+  _debug: Logger,
+  // Websocket connected to the client used to send messages back and forth.
+  _network: ModuleWSS,
+  // Shared state with module's client.
+  _state: ModuleState,
+  // Polygon representing the outer shape of the entire wall area.
+  _wallGeometry: Polygon,
+) {
+  class TemplateServer extends Server {
+    // Notification that your module has been selected next in the queue.
+    willBeShownSoon(_deadline: number): Promise<void> | void {}
+
+    // Notification that your module should execute a tick of work.
+    tick(_time: number, _delta: number) {}
+
+    // Notification that your module has been removed from the clients.
+    dispose() {}
+  }
+
+  return { server: TemplateServer };
+}

--- a/lib/inject.ts
+++ b/lib/inject.ts
@@ -31,13 +31,13 @@ export default function inject<R>(
     .map((arg) => arg.trim())
     .filter((arg) => arg)
     // Assign values from sandbox.
-    .map((a) => {
-      if (!(a in sandbox)) {
+    .map((arg) => {
+      if (!(arg in sandbox)) {
         console.warn(
-          `inject error: unknown argument '${a}', use one of: ${Object.keys(sandbox)}`,
+          `inject error: unknown argument '${arg}', use one of: ${Object.keys(sandbox)}`,
         );
       }
-      return sandbox[a];
+      return sandbox[arg];
     });
 
   return fn.apply(null, args);

--- a/lib/inject.ts
+++ b/lib/inject.ts
@@ -21,7 +21,7 @@ export default function inject<R>(
   sandbox: Record<string, unknown>,
 ): R {
   const args = fn.toString()
-    // Extract argument block between the first parenthesis.
+    // Extract argument block between the first parentheses.
     .match(/\(([^)]*)/)![1]
     // Remove comments.
     .replaceAll(/\/\*[^]*\*\//mg, "")


### PR DESCRIPTION
I thought it would be nice to have a base module that contains the entirety of the API for contributors. Especially since the load functions look like they're being slurped and their arguments are being injected with reflection.

~~This doesn't work right now because `wallGeometry` is undefined in `willBeShownSoon`, but I wanted to get your initial feedback on the bones and see if this is a mergeable idea.~~

Also added some code to remove comments in the inject logic to fix the above error.