### PR TITLE
Rewrite calendar state tracking.

### DIFF
--- a/server/flags.ts
+++ b/server/flags.ts
@@ -97,6 +97,12 @@ const FLAG_DEFS = [
     defaultValue: "",
     description: "Id of a Google Calendar used to configure the wall.",
   },
+  {
+    name: "calendar_v2",
+    type: Boolean,
+    defaultValue: false,
+    description: "Use updated calendar strategy.",
+  },
 ];
 
 export interface Flags {
@@ -116,6 +122,7 @@ export interface Flags {
   https_cert: string;
   https_key: string;
   calendar_id: string;
+  calendar_v2: boolean;
 }
 
 export const flags = commandLineArgs(FLAG_DEFS) as Flags;

--- a/server/playlist/calendar/fetch.ts
+++ b/server/playlist/calendar/fetch.ts
@@ -1,0 +1,102 @@
+import {
+  Calendar,
+  Events as CalendarResponse,
+} from "https://googleapis.deno.dev/v1/calendar:v3.ts";
+import { easyLog } from "../../../lib/log.ts";
+import { ModuleDescription, parseDescription } from "./parse.ts";
+import { GoogleAuth } from "../../util/authenticate_google_api.ts";
+import * as credentials from "../../util/credentials.ts";
+import { JWTInput } from "https://googleapis.deno.dev/_/base@v1/auth/jwt.ts";
+import { createHash } from "https://deno.land/std@0.101.0/hash/mod.ts";
+
+// Window of time both before and after the current time for which to fetch events.
+// Note that this also means events that start outside the window will not be
+// considered. Depending on the implementation of the Calendar API we might have
+// issues if events are longer than this window.
+const FETCH_WINDOW_HRS = 12;
+
+const log = easyLog("wall:calendar");
+
+export interface Event extends ModuleDescription {
+  descriptionHash: string;
+  start: Date;
+  end: Date;
+}
+
+// Load calendar events.
+// Returns an ordered list of the events around the current time.
+export async function fetchEvents(
+  id: string,
+  credsKey: string,
+): Promise<Event[]> {
+  const timeNow = new Date();
+  const timeMin = new Date(Date.now() - FETCH_WINDOW_HRS * 60 * 60 * 1000);
+  const timeMax = new Date(Date.now() + FETCH_WINDOW_HRS * 60 * 60 * 1000);
+
+  // Create API client.
+  const creds = credentials.get(credsKey) as JWTInput;
+  if (!creds) {
+    throw new Error(
+      `Calendar schedule requires ${credsKey}, but these creds were not found`,
+    );
+  }
+  const auth = new GoogleAuth(creds);
+  auth.setScopes(["https://www.googleapis.com/auth/calendar.events.readonly"]);
+  const calendarClient = new Calendar(auth);
+
+  // Fetch calendar data.
+  let results: CalendarResponse;
+  try {
+    results = await calendarClient.eventsList(id, {
+      timeMin,
+      timeMax,
+      singleEvents: true,
+      orderBy: "startTime",
+    });
+  } catch (e) {
+    log.error(`Got error when loading calendar events: ${e.message}`);
+    return [];
+  }
+
+  // Clean up and parse results into events.
+  const events: Event[] = [];
+  for (const item of results.items || []) {
+    const startDate = item.start?.dateTime || item.start?.date;
+    const endDate = item.end?.dateTime || item.end?.date;
+    if (!startDate || !endDate || !item.description) {
+      continue;
+    }
+
+    try {
+      events.push({
+        descriptionHash: createHash("md5").update(item.description).toString(),
+        start: startDate,
+        end: endDate,
+        ...parseDescription(item.description),
+      });
+    } catch {
+      continue;
+    }
+  }
+
+  // Order events by their start time.
+  events.sort((a, b) => a.start < b.start ? -1 : 1);
+
+  // Log event count and next event start time.
+  let nextEvent: Event | null = null;
+  for (const event of events) {
+    if (event.start > timeNow) {
+      nextEvent = event;
+      break;
+    }
+  }
+  if (nextEvent === null) {
+    log(`Fetched ${events.length} event(s).`);
+  } else {
+    log(
+      `Fetched ${events.length} events. Next event starting at ${nextEvent?.start}`,
+    );
+  }
+
+  return events;
+}

--- a/server/playlist/calendar/parse.ts
+++ b/server/playlist/calendar/parse.ts
@@ -1,0 +1,74 @@
+import { BrickJson, ExtendsBrickJson } from "../playlist.ts";
+import { CreditAuthorTitleJson } from "../../../client/title_card.ts";
+import { easyLog } from "../../../lib/log.ts";
+
+const log = easyLog("wall:calendar");
+
+export interface ModuleDescription {
+  moduleDef?: BrickJson;
+
+  // Fallback used when no moduleDef is provided.
+  moduleName: string;
+}
+
+export function parseDescription(desc: string): ModuleDescription {
+  // Check if JSON when starts with "{".
+  if (desc.includes("{")) {
+    try {
+      const moduleDef = JSON.parse(desc);
+      return { moduleDef, moduleName: moduleDef.name };
+    } catch (e) {
+      log.error(`Error parsing module def as JSON:`, desc);
+      log.error(e);
+      throw e;
+    }
+  }
+
+  // Parse as slideshow key/value pairs when contains ":".
+  // Values will override and extend the slideshow module.
+  if (desc.includes(":")) {
+    const credit: CreditAuthorTitleJson = { title: "" };
+
+    const config = {
+      load: {},
+      display: {
+        fullscreen: {},
+      },
+      // deno-lint-ignore no-explicit-any
+    } as any;
+
+    const brickjson = {
+      name: "",
+      credit,
+      extends: "slideshow",
+      config,
+    } as ExtendsBrickJson;
+
+    for (const line of desc.split(/\n+/g)) {
+      const [key, value] = line.split(/\s*:\s*/);
+      if (key === "name") {
+        brickjson.name = value;
+      } else if (key === "title") {
+        credit.title = value;
+      } else if (key === "drive-folder") {
+        config.load.drive = config.load.drive || {};
+        config.load.drive.folderIds = config.load.drive.folderIds || [];
+        config.load.drive.folderIds.push(...value.split(","));
+      } else if (key === "drive-file") {
+        config.load.drive = config.load.drive || {};
+        config.load.drive.fileIds = config.load.drive.fileIds || [];
+        config.load.drive.fileIds.push(...value.split(","));
+      } else if (key === "period") {
+        config.display.fullscreen.period = Number(value);
+      } else if (key === "split" && value === "true") {
+        config.display.fullscreen.split = true;
+      } else if (key === "shuffle" && value === "true") {
+        config.display.fullscreen.shuffle = true;
+      }
+    }
+    return { moduleDef: brickjson, moduleName: brickjson.name };
+  }
+
+  // Fallback using description as module name.
+  return { moduleName: desc };
+}

--- a/server/playlist/calendar/state.ts
+++ b/server/playlist/calendar/state.ts
@@ -1,0 +1,78 @@
+import { PlaylistDriver } from "../playlist_driver.ts";
+import { library } from "../../modules/library.ts";
+import { easyLog } from "../../../lib/log.ts";
+import { Event, fetchEvents } from "./fetch.ts";
+
+const log = easyLog("wall:calendar");
+
+const FETCH_EVENTS_INTERVAL_MS = /* 1 minute */ 60 * 1000;
+const SYNC_EVENTS_INTERVAL_MS = /* 10 seconds */ 10 * 1000;
+
+// Unique identifier of the current calendar event being displayed.
+// Null when the wall state should be default/reset.
+let currentScheduledModuleHash: string | null = null;
+
+export async function startSchedule(
+  id: string,
+  credsKey: string,
+  playlistDriver: PlaylistDriver,
+) {
+  // Set up loop that pulls calendar events.
+  let events = await fetchEvents(id, credsKey);
+  setInterval(async () => {
+    events = await fetchEvents(id, credsKey);
+  }, FETCH_EVENTS_INTERVAL_MS);
+
+  // Set up loop that updates the wall according to calendar events.
+  updateState(events, playlistDriver);
+  setInterval(() => {
+    updateState(events, playlistDriver);
+  }, SYNC_EVENTS_INTERVAL_MS);
+}
+
+async function updateState(events: Event[], playlistDriver: PlaylistDriver) {
+  const timeNow = new Date();
+  const targetEvent = findEventAtTime(timeNow, events);
+
+  // Nothing is scheduled.
+  if (targetEvent === null) {
+    // Already reset playlist.
+    if (currentScheduledModuleHash === null) return;
+
+    log(`No module coming up. Back to normal playlist`);
+    await playlistDriver.resetPlaylist();
+    currentScheduledModuleHash = null;
+    return;
+  }
+
+  const targetEventName = targetEvent.moduleDef?.name || targetEvent.moduleName;
+
+  // Target module is already playing.
+  if (currentScheduledModuleHash === targetEvent.descriptionHash) {
+    return;
+  }
+
+  // Switch to the new module.
+  if (targetEvent.moduleDef !== undefined) {
+    log(`Loading module def: `, targetEvent.moduleDef);
+    library.loadAllModules([targetEvent.moduleDef]);
+  }
+  log(`Scheduling module from calendar: "${targetEventName}"`);
+  playlistDriver.playModule(targetEventName, true);
+  currentScheduledModuleHash = targetEvent.descriptionHash;
+}
+
+// Finds the event that should be playing at any arbitrary time.
+// Returns null when nothing should be playing.
+// Returns the event with the latest start time in case of overlaps.
+export function findEventAtTime(date: Date, events: Event[]): Event | null {
+  let foundEvent: Event | null = null;
+  for (const event of events) {
+    if (event.start <= date && event.end >= date) {
+      if (foundEvent === null || foundEvent.start < event.start) {
+        foundEvent = event;
+      }
+    }
+  }
+  return foundEvent;
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -36,6 +36,7 @@ import { library } from "./modules/library.ts";
 import { flags } from "./flags.ts";
 import { consoleLogger } from "./util/console_logger.ts";
 import { startSchedule } from "./playlist/calendar_playlist.ts";
+import { startSchedule as startScheduleV2 } from "./playlist/calendar/state.ts";
 
 addLogger(makeConsoleLogger(consoleLogger, time.now));
 addLogger(captureLog, "wall");
@@ -93,9 +94,19 @@ driver.start(playlist);
 
 if (flags.calendar_id) {
   log(`Starting events for calendar: ${flags.calendar_id}`);
-  await startSchedule(
-    flags.calendar_id,
-    "googleserviceaccountkey",
-    driver,
-  );
+
+  if (flags.calendar_v2) {
+    log(`Using calendar v2`);
+    await startScheduleV2(
+      flags.calendar_id,
+      "googleserviceaccountkey",
+      driver,
+    );
+  } else {
+    await startSchedule(
+      flags.calendar_id,
+      "googleserviceaccountkey",
+      driver,
+    );
+  }
 }


### PR DESCRIPTION
We are having issues with the wall reliably switching back to the default playlist after scheduled events end.

I ended up reimplementing the strategy of how we maintain the state because the current one relies on long-lived timeouts and I was having a hard time figuring out what was going wrong.

The new implementation fetches events every minute. Separately there's a loop firing every 10s that diffs the current state of the wall against what it should look like and updates the state if necessary.

I've added this implementation behind a flag so that we can revert quickly in case of an issue. I tested this pretty extensively against the prod calendar locally, but it's not the same thing.