### PR TITLE
feat: add new penrose_tiles module with testonly=true; improve shell scripts a bit

### DIFF
--- a/bin/run_1x1.sh
+++ b/bin/run_1x1.sh
@@ -38,10 +38,17 @@ readonly BRICK_PID="$!"
 ./status/run_status.sh &
 readonly STATUS_PID="$!"
 
-# Figure out the Chrome path
-(uname -a | grep "Darwin" > /dev/null) \
-&& readonly CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
-|| readonly CHROME="google-chrome"
+# Figure out the Chrome path (if not set)
+if [ -z "$CHROME" ]; then
+  case $(uname) in
+  Darwin)
+    CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    ;;
+  *)
+    CHROME=google-chrome
+    ;;
+  esac
+fi
 
 # Boot two chromes:
 "$CHROME" \

--- a/bin/start_2x2_clients.sh
+++ b/bin/start_2x2_clients.sh
@@ -19,15 +19,17 @@ set -x
 
 WINDOW_SIZE="480,270"
 
-case $(uname) in
-Darwin)
+if [ -z $CHROME ]; then
+  case $(uname) in
+  Darwin)
     CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
     WINDOW_SIZE="480,292"
     ;;
-*)
+  *)
     CHROME=google-chrome
     ;;
-esac
+  esac
+fi
 
 verbose=0
 

--- a/bin/start_chev6_clients.sh
+++ b/bin/start_chev6_clients.sh
@@ -17,14 +17,16 @@
 
 set -x
 
-case $(uname) in
-Darwin)
-    CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-    ;;
-*)
-    CHROME=google-chrome
-    ;;
-esac
+if [ -z $CHROME ]; then
+    case $(uname) in
+    Darwin)
+        CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        ;;
+    *)
+        CHROME=google-chrome
+        ;;
+    esac
+fi
 
 verbose=0
 

--- a/demo_modules/penrose_tiles/brick.json
+++ b/demo_modules/penrose_tiles/brick.json
@@ -1,6 +1,5 @@
 {
     "name": "penrose_tiles",
-    "testonly": true,
     "client_path": "./penrose_tiles_client.ts",
     "server_path": "./penrose_tiles_server.ts",
     "credit": {

--- a/demo_modules/penrose_tiles/brick.json
+++ b/demo_modules/penrose_tiles/brick.json
@@ -1,0 +1,11 @@
+{
+    "name": "penrose_tiles",
+    "testonly": true,
+    "client_path": "./penrose_tiles_client.ts",
+    "server_path": "./penrose_tiles_server.ts",
+    "credit": {
+      "title": "Penrose Tiles",
+      "author": "Peter Aarestad"
+    }
+}
+

--- a/demo_modules/penrose_tiles/constants.ts
+++ b/demo_modules/penrose_tiles/constants.ts
@@ -1,0 +1,2 @@
+export const PHI = (1 + Math.sqrt(5)) / 2; // the Golden Ratio
+export const PI_OVER_5 = Math.PI / 5; // 72 degrees, the primary angle used in P2 tiles

--- a/demo_modules/penrose_tiles/penrose_tiles_client.ts
+++ b/demo_modules/penrose_tiles/penrose_tiles_client.ts
@@ -1,0 +1,143 @@
+import { Client } from "../../client/modules/module_interface.ts";
+import { Polygon } from "../../lib/math/polygon2d.ts";
+import { CanvasSurface } from "../../client/surface/canvas_surface.ts";
+import { Rectangle } from "../../lib/math/rectangle.ts";
+import {
+  CurrentValueInterpolator,
+  ModuleState,
+  NumberLerpInterpolator,
+  SharedState,
+} from "../../client/network/state_manager.ts";
+import { P2TileType, PenroseTilesState, TileGenerations } from "./tile.ts";
+
+type DrawableTileGeneration = Array<{
+  path: Path2D;
+  type: P2TileType;
+}>;
+
+const LINE_WIDTH = 4;
+
+export function load(
+  state: ModuleState,
+  wallGeometry: Polygon,
+) {
+  class PenroseTilesClient extends Client {
+    ctx!: CanvasRenderingContext2D;
+    tilesState?: SharedState;
+    drawableTiles: DrawableTileGeneration[] = [];
+
+    // Notification that your module has been selected next in the queue.
+    willBeShownSoon(
+      container: HTMLElement,
+      _deadline: number,
+    ): Promise<void> | void {
+      this.surface = new CanvasSurface(container, wallGeometry);
+      this.ctx = (this.surface as CanvasSurface).context;
+      this.ctx.lineWidth = LINE_WIDTH;
+      this.ctx.lineJoin = "bevel";
+
+      this.tilesState = state.define("tiles", {
+        currentGeneration: CurrentValueInterpolator,
+        tileGenerations: [[
+          {
+            points: CurrentValueInterpolator,
+            angle: CurrentValueInterpolator,
+            size: CurrentValueInterpolator,
+            type: CurrentValueInterpolator,
+            extents: CurrentValueInterpolator,
+          },
+        ]],
+        kiteHue: NumberLerpInterpolator,
+        dartHue: NumberLerpInterpolator,
+      });
+    }
+
+    beginFadeIn(_time: number) {}
+
+    finishFadeIn() {}
+
+    private precomputeTiles(
+      tileGenerations: TileGenerations,
+    ): DrawableTileGeneration[] {
+      return tileGenerations.map((tileGen) => (
+        tileGen.filter((st) => {
+          // Filter out tiles that aren't visible on this screen
+          if (this.surface) {
+            return Rectangle.deserialize(st.extents)?.intersects(
+              this.surface.virtualRect,
+            );
+          }
+
+          return false;
+        }).map((st) => {
+          // Precompute paths
+          const path = new Path2D();
+          path.moveTo(st.points[0].x, st.points[0].y);
+
+          for (const p of st.points.slice(1)) {
+            path.lineTo(p.x, p.y);
+          }
+
+          path.closePath();
+
+          return {
+            path,
+            type: st.type,
+          };
+        })
+      ));
+    }
+
+    draw(time: number, _delta: number) {
+      if (!this.surface) {
+        return;
+      }
+
+      const state = this.tilesState?.get(time) as PenroseTilesState;
+
+      if (!state) {
+        return;
+      }
+
+      if (this.drawableTiles.length === 0) {
+        const tileGenerations = (this.tilesState?.get(0) as PenroseTilesState)
+          ?.tileGenerations;
+
+        if (!tileGenerations) {
+          return;
+        }
+
+        this.drawableTiles.push(...this.precomputeTiles(tileGenerations));
+      }
+
+      (this.surface as CanvasSurface).pushOffset();
+
+      // hard-code saturation at 100% and lightness at 50% for now
+      const kiteFillStyle = `hsl(${state.kiteHue}turn 100% 50%`;
+      const dartFillStyle = `hsl(${state.dartHue}turn 100% 50%`;
+
+      for (const tile of this.drawableTiles[state.currentGeneration]) {
+        this.ctx.fillStyle = tile.type == P2TileType.Kite
+          ? kiteFillStyle
+          : dartFillStyle;
+
+        this.ctx.stroke(tile.path);
+        this.ctx.fill(tile.path);
+      }
+
+      (this.surface as CanvasSurface).popOffset();
+    }
+
+    // Notification that your module has started to fade out.
+    beginFadeOut() {}
+
+    // Notification that your module has finished fading out.
+    finishFadeOut() {
+      if (this.surface) {
+        this.surface.destroy();
+      }
+    }
+  }
+
+  return { client: PenroseTilesClient };
+}

--- a/demo_modules/penrose_tiles/penrose_tiles_server.ts
+++ b/demo_modules/penrose_tiles/penrose_tiles_server.ts
@@ -1,0 +1,75 @@
+import { Server } from "../../server/modules/module_interface.ts";
+import { ModuleState } from "../../server/network/state_manager.ts";
+import { Polygon } from "../../lib/math/polygon2d.ts";
+import { deflateTiles, Tile, TileGenerations } from "./tile.ts";
+
+export function load(
+  state: ModuleState,
+  wallGeometry: Polygon,
+) {
+  const MAX_GENS = 7;
+  const CYCLE_LENGTH_MILLIS = 5_000;
+
+  class PenroseTilesServer extends Server {
+    previousGenTimeMs = 0;
+    firstDraw = 0;
+    currentGeneration = 0;
+
+    willBeShownSoon(_deadline: number): Promise<void> | void {
+      const center = wallGeometry.extents.center();
+
+      let lastGen = Tile.protoTiles(center, wallGeometry.extents.w / 2.5);
+
+      const tileGenerations: TileGenerations = [] as TileGenerations;
+
+      tileGenerations[0] = lastGen.map((t) => t.serialize());
+
+      for (let i = 1; i < MAX_GENS; ++i) {
+        // Deflate the tiles, then de-dupe them by id (i.e. its center)
+        lastGen = deflateTiles(lastGen);
+        // lastGen = Array.from(new Map(lastGen.map((t) => [t.id, t])).values());
+        tileGenerations[i] = lastGen.map((t) => t.serialize());
+      }
+
+      state.store(
+        "tiles",
+        0,
+        {
+          currentGeneration: 0,
+          kiteHue: 0,
+          dartHue: 1 / 4,
+          tileGenerations,
+        },
+      );
+    }
+
+    // Notification that your module should execute a tick of work.
+    tick(time: number, _delta: number) {
+      if (this.previousGenTimeMs === 0) {
+        this.previousGenTimeMs = time;
+        this.firstDraw = time;
+      }
+
+      // Cycle through the wheel every 10 seconds
+      const kiteHue = (time - this.firstDraw) / CYCLE_LENGTH_MILLIS;
+      const dartHue = kiteHue + 1 / 4;
+      // Change generations every cycle up to MAX_GENS-1
+      const currentGeneration = Math.min(Math.floor(kiteHue), MAX_GENS - 1);
+
+      state.store(
+        "tiles",
+        time,
+        {
+          currentGeneration,
+          kiteHue,
+          dartHue,
+        },
+      );
+    }
+
+    // Notification that your module has been removed from the clients.
+    dispose() {}
+  }
+
+  return { server: PenroseTilesServer };
+}

--- a/demo_modules/penrose_tiles/tile.ts
+++ b/demo_modules/penrose_tiles/tile.ts
@@ -1,0 +1,161 @@
+/**
+ * Code adapted from https://rosettacode.org/wiki/Penrose_tiling#Java
+ * License: https://creativecommons.org/licenses/by-sa/4.0/
+ */
+
+import { PHI, PI_OVER_5 } from "./constants.ts";
+import { Point } from "../../lib/math/vector2d.ts";
+import { Polygon } from "../../lib/math/polygon2d.ts";
+
+// The "P2" Penrose tile types
+// see https://en.wikipedia.org/wiki/Penrose_tiling#Kite_and_dart_tiling_(P2)
+export enum P2TileType {
+  Kite = 0,
+  Dart,
+}
+
+export type SerializedTile = Pick<Tile, "points"|"angle"|"size"|"type"> & {
+  extents: string; // serialized Rectangle
+}
+
+export type TileGenerations = SerializedTile[][];
+
+export type PenroseTilesState = {
+  readonly tileGenerations?: TileGenerations;
+  readonly currentGeneration: number;
+  readonly kiteHue: number;
+  readonly dartHue: number;
+}
+
+// An individual tile
+export class Tile extends Polygon {
+  private constructor(
+    readonly points: Point[],
+    readonly angle: number,
+    readonly size: number,
+    readonly type: P2TileType,
+  ) {
+    super(points);
+  }
+
+  // Use the serialized extents as an "id"
+  get id(): string {
+    return this.extents.serialize();
+  }
+
+  static fromOrigin(
+    origin: Point,
+    angle: number,
+    size: number,
+    type: P2TileType,
+  ): Tile {
+    const sideRatios = {
+      [P2TileType.Kite]: [PHI, PHI, PHI],
+      [P2TileType.Dart]: [-PHI, -1, -PHI],
+    };
+
+    let a = angle - PI_OVER_5;
+
+    const points = [origin];
+
+    for (let i = 0; i < 3; i++) {
+      const x = origin.x + sideRatios[type][i] * size * Math.cos(a);
+      const y = origin.y - sideRatios[type][i] * size * Math.sin(a);
+      points.push({ x, y });
+      a += PI_OVER_5;
+    }
+
+    return new Tile(points, angle, size, type);
+  }
+
+  static protoTiles(
+    center: Point,
+    size: number,
+  ): readonly Tile[] {
+    const protoTiles = [];
+
+    for (
+      let a = Math.PI / 2 + PI_OVER_5;
+      a < 3 * Math.PI;
+      a += 2 * PI_OVER_5
+    ) {
+      protoTiles.push(
+        Tile.fromOrigin(
+          center,
+          a,
+          size,
+          P2TileType.Kite,
+        ),
+      );
+    }
+
+    return protoTiles;
+  }
+
+  serialize(): SerializedTile {
+    return {
+      points: this.points,
+      angle: this.angle,
+      size: this.size,
+      type: this.type,
+      extents: this.extents.serialize(),
+    };
+  }
+
+  static deserialize(s: SerializedTile): Tile {
+    return new Tile(s.points, s.angle, s.size, s.type);
+  }
+}
+
+// "Deflate" the given tiles to the next generation
+export function deflateTiles(tiles: readonly Tile[]): readonly Tile[] {
+  const newTiles: Tile[] = [];
+
+  for (const tile of tiles) {
+    const x = tile.points[0].x;
+    const y = tile.points[0].y;
+    const a = tile.angle;
+    const size = tile.size / PHI;
+
+    if (tile.type === P2TileType.Dart) {
+      newTiles.push(
+        Tile.fromOrigin({ x, y }, a + 5 * PI_OVER_5, size, P2TileType.Kite),
+      );
+
+      for (let i = 0, sign = 1; i < 2; i++, sign *= -1) {
+        const nx = x + Math.cos(a - 4 * PI_OVER_5 * sign) * PHI * tile.size;
+        const ny = y - Math.sin(a - 4 * PI_OVER_5 * sign) * PHI * tile.size;
+
+        newTiles.push(
+          Tile.fromOrigin(
+            { x: nx, y: ny },
+            a - 4 * PI_OVER_5 * sign,
+            size,
+            P2TileType.Dart,
+          ),
+        );
+      }
+    } else {
+      for (let i = 0, sign = 1; i < 2; i++, sign *= -1) {
+        newTiles.push(
+          Tile.fromOrigin({ x, y }, a - 4 * PI_OVER_5 * sign, size, P2TileType.Dart),
+        );
+
+        const nx = x + Math.cos(a - PI_OVER_5 * sign) * PHI * tile.size;
+        const ny = y - Math.sin(a - PI_OVER_5 * sign) * PHI * tile.size;
+
+        newTiles.push(
+          Tile.fromOrigin(
+            { x: nx, y: ny },
+            a + 3 * PI_OVER_5 * sign,
+            size,
+            P2TileType.Kite,
+          ),
+        );
+      }
+    }
+  }
+  // TODO remove duplicates?
+
+  return newTiles;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -725,17 +725,17 @@
       }
     },
     "node_modules/cacheable-request": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.2.tgz",
-      "integrity": "sha512-KxjQZM3UIo7/J6W4sLpwFvu1GB3Whv8NtZ8ZrUL284eiQjiXeeqWTdhixNrp/NLZ/JNuFBo6BD4ZaO8ZJ5BN8Q==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.7.tgz",
+      "integrity": "sha512-I4SA6mKgDxcxVbSt/UmIkb9Ny8qSkg6ReBHtAAXnZHk7KOSx5g3DTiAOaYzcHCs6oOdHn+bip9T48E6tMvK9hw==",
       "dev": true,
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.1",
         "get-stream": "^6.0.1",
-        "http-cache-semantics": "^4.1.0",
-        "keyv": "^4.5.0",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.2",
         "mimic-response": "^4.0.0",
-        "normalize-url": "^7.2.0",
+        "normalize-url": "^8.0.0",
         "responselike": "^3.0.0"
       },
       "engines": {
@@ -1957,9 +1957,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http-errors": {
@@ -2993,12 +2993,12 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-7.2.0.tgz",
-      "integrity": "sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
       "dev": true,
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4818,9 +4818,9 @@
       }
     },
     "node_modules/vm2": {
-      "version": "3.9.11",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.11.tgz",
-      "integrity": "sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.7.0",
@@ -5688,17 +5688,17 @@
       "dev": true
     },
     "cacheable-request": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.2.tgz",
-      "integrity": "sha512-KxjQZM3UIo7/J6W4sLpwFvu1GB3Whv8NtZ8ZrUL284eiQjiXeeqWTdhixNrp/NLZ/JNuFBo6BD4ZaO8ZJ5BN8Q==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.7.tgz",
+      "integrity": "sha512-I4SA6mKgDxcxVbSt/UmIkb9Ny8qSkg6ReBHtAAXnZHk7KOSx5g3DTiAOaYzcHCs6oOdHn+bip9T48E6tMvK9hw==",
       "dev": true,
       "requires": {
         "@types/http-cache-semantics": "^4.0.1",
         "get-stream": "^6.0.1",
-        "http-cache-semantics": "^4.1.0",
-        "keyv": "^4.5.0",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.2",
         "mimic-response": "^4.0.0",
-        "normalize-url": "^7.2.0",
+        "normalize-url": "^8.0.0",
         "responselike": "^3.0.0"
       },
       "dependencies": {
@@ -6593,9 +6593,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-errors": {
@@ -7326,9 +7326,9 @@
       }
     },
     "normalize-url": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-7.2.0.tgz",
-      "integrity": "sha512-uhXOdZry0L6M2UIo9BTt7FdpBDiAGN/7oItedQwPKh8jh31ZlvC8U9Xl/EJ3aijDHaywXTW3QbZ6LuCocur1YA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
       "dev": true
     },
     "npm-run-path": {
@@ -8658,9 +8658,9 @@
       }
     },
     "vm2": {
-      "version": "3.9.11",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.11.tgz",
-      "integrity": "sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==",
+      "version": "3.9.17",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.17.tgz",
+      "integrity": "sha512-AqwtCnZ/ERcX+AVj9vUsphY56YANXxRuqMb7GsDtAr0m0PcQX3u0Aj3KWiXM0YAHy7i6JEeHrwOnwXbGYgRpAw==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",


### PR DESCRIPTION
Creates a new `penrose_tiles` module with testonly set - I am hoping to be able to do a "live" test of this soon (next week maybe?) and need guidance as to how to do that. Also updates the run scripts to allow the user to set the `CHROME` env variable outside of the script.

Future work:

- some sort of constant zoom so we can go beyond 7 iterations without creating zillions of tiles
- some sort of animated transition between iterations