### PR TITLE
Update error_controller.ts DOM text reinterpreted as HTML

### DIFF
--- a/status/static/error_controller.ts
+++ b/status/static/error_controller.ts
@@ -82,7 +82,7 @@ export class ErrorController {
     for (const e of this.errors) {
       if (!e.element) {
         const newErrorEl = document.createElement("div");
-        newErrorEl.innerHTML = `<div>
+        newErrorEl.innerText = `<div>
           <span class="timestamp"></span>
           <span class="clients"></span>
           <span class="module"></span>:


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.